### PR TITLE
feat: add Dockerfile to build from specific langflow branch

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -1,0 +1,49 @@
+FROM python:3.12-slim
+
+# Set environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONUNBUFFERED=1
+ENV RUSTFLAGS="--cfg reqwest_unstable"
+
+# Accept build arguments for git repository and branch
+ARG GIT_REPO=https://github.com/langflow-ai/langflow.git
+ARG GIT_BRANCH=load_flows_autologin_false   
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    ca-certificates \
+    gnupg \
+    npm \
+    rustc cargo pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv for faster Python package management
+RUN pip install uv
+
+# Clone the repository and checkout the specified branch
+RUN git clone --depth 1 --branch ${GIT_BRANCH} ${GIT_REPO} /app
+
+# Install backend dependencies
+RUN uv sync --frozen --no-install-project --no-editable --extra postgresql
+
+# Build frontend
+WORKDIR /app/src/frontend
+RUN npm ci && \
+    npm run build && \
+    mkdir -p /app/src/backend/base/langflow/frontend && \
+    cp -r build/* /app/src/backend/base/langflow/frontend/
+
+# Return to app directory and install the project
+WORKDIR /app
+RUN uv sync --frozen --no-dev --no-editable --extra postgresql
+
+# Expose ports
+EXPOSE 7860
+
+# Start the backend server
+CMD ["uv", "run", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]


### PR DESCRIPTION
This pull request introduces a new `Dockerfile.langflow` to streamline building and running the Langflow application in a containerized environment. The Dockerfile automates the setup of system dependencies, clones the Langflow repository, builds the frontend, and prepares the backend for deployment.

**Containerization and build automation:**

* Added a new `Dockerfile.langflow` that uses the `python:3.12-slim` base image and sets up environment variables for Python and Rust compilation.
* Installs essential system packages, including build tools, Node.js (`npm`), Rust, and PostgreSQL dependencies, to support both backend and frontend builds.
* Clones the Langflow repository from a configurable branch and installs backend dependencies using `uv` for efficient Python package management.
* Builds the frontend with `npm`, copies the build artifacts into the backend directory, and exposes port 7860 for application access.
* Defines the container entrypoint to launch the Langflow backend server, making the application ready for deployment.