### PR TITLE
task timings

### DIFF
--- a/frontend/src/components/task-notification-menu.tsx
+++ b/frontend/src/components/task-notification-menu.tsx
@@ -76,6 +76,22 @@ export function TaskNotificationMenu() {
     return null
   }
 
+  const formatDuration = (seconds?: number) => {
+    if (!seconds || seconds < 0) return null
+    
+    if (seconds < 60) {
+      return `${Math.round(seconds)}s`
+    } else if (seconds < 3600) {
+      const mins = Math.floor(seconds / 60)
+      const secs = Math.round(seconds % 60)
+      return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`
+    } else {
+      const hours = Math.floor(seconds / 3600)
+      const mins = Math.floor((seconds % 3600) / 60)
+      return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`
+    }
+  }
+
   const formatRelativeTime = (dateString: string) => {
     // Handle different timestamp formats
     let date: Date
@@ -153,6 +169,11 @@ export function TaskNotificationMenu() {
                     </div>
                     <CardDescription className="text-xs">
                       Started {formatRelativeTime(task.created_at)}
+                      {formatDuration(task.duration_seconds) && (
+                        <span className="ml-2 text-muted-foreground">
+                          • {formatDuration(task.duration_seconds)}
+                        </span>
+                      )}
                     </CardDescription>
                   </CardHeader>
                   {formatTaskProgress(task) && (
@@ -256,6 +277,11 @@ export function TaskNotificationMenu() {
                         </div>
                         <div className="text-xs text-muted-foreground">
                           {formatRelativeTime(task.updated_at)}
+                          {formatDuration(task.duration_seconds) && (
+                            <span className="ml-2">
+                              • {formatDuration(task.duration_seconds)}
+                            </span>
+                          )}
                         </div>
                         {/* Show final results for completed tasks */}
                         {task.status === 'completed' && formatTaskProgress(task)?.detailed && (

--- a/frontend/src/contexts/task-context.tsx
+++ b/frontend/src/contexts/task-context.tsx
@@ -13,6 +13,7 @@ export interface Task {
   failed_files?: number
   created_at: string
   updated_at: string
+  duration_seconds?: number
   result?: Record<string, unknown>
   error?: string
   files?: Record<string, Record<string, unknown>>

--- a/src/models/tasks.py
+++ b/src/models/tasks.py
@@ -20,6 +20,11 @@ class FileTask:
     retry_count: int = 0
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
+    
+    @property
+    def duration_seconds(self) -> float:
+        """Duration in seconds from creation to last update"""
+        return self.updated_at - self.created_at
 
 
 @dataclass
@@ -33,3 +38,8 @@ class UploadTask:
     status: TaskStatus = TaskStatus.PENDING
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
+    
+    @property
+    def duration_seconds(self) -> float:
+        """Duration in seconds from creation to last update"""
+        return self.updated_at - self.created_at

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -224,6 +224,7 @@ class TaskService:
                 "retry_count": file_task.retry_count,
                 "created_at": file_task.created_at,
                 "updated_at": file_task.updated_at,
+                "duration_seconds": file_task.duration_seconds,
             }
 
         return {
@@ -235,6 +236,7 @@ class TaskService:
             "failed_files": upload_task.failed_files,
             "created_at": upload_task.created_at,
             "updated_at": upload_task.updated_at,
+            "duration_seconds": upload_task.duration_seconds,
             "files": file_statuses,
         }
 
@@ -262,6 +264,7 @@ class TaskService:
                     "failed_files": upload_task.failed_files,
                     "created_at": upload_task.created_at,
                     "updated_at": upload_task.updated_at,
+                    "duration_seconds": upload_task.duration_seconds,
                 }
 
         # First, add user-owned tasks; then shared anonymous;


### PR DESCRIPTION
This pull request adds support for displaying task durations in the user interface by calculating and passing `duration_seconds` for tasks from the backend to the frontend. The changes include new properties and formatting functions to show durations alongside timestamps for both file and upload tasks.

**Backend: Task duration calculation and exposure**
* Added a `duration_seconds` property to both the `FileTask` and `UploadTask` models in `src/models/tasks.py`, which computes the duration as the difference between `updated_at` and `created_at`. [[1]](diffhunk://#diff-f014ea92c81b0f27a6551648ce73fef63363ca901cff4b534dadb489ad8e4a14R24-R28) [[2]](diffhunk://#diff-f014ea92c81b0f27a6551648ce73fef63363ca901cff4b534dadb489ad8e4a14R41-R45)
* Updated the task service (`src/services/task_service.py`) to include `duration_seconds` in the returned status dictionaries for both file and upload tasks, ensuring this value is available to the frontend. [[1]](diffhunk://#diff-2edca6e457e83543daf50ad16a8bbdb353abc71c217395c2f3620baa12b407feR227) [[2]](diffhunk://#diff-2edca6e457e83543daf50ad16a8bbdb353abc71c217395c2f3620baa12b407feR239) [[3]](diffhunk://#diff-2edca6e457e83543daf50ad16a8bbdb353abc71c217395c2f3620baa12b407feR267)

**Frontend: Displaying task duration**
* Updated the `Task` interface in `frontend/src/contexts/task-context.tsx` to include an optional `duration_seconds` property.
* Added a `formatDuration` helper function to `frontend/src/components/task-notification-menu.tsx` to format durations into human-readable strings (e.g., "1m 30s", "2h 5m").
* Modified the task notification menu UI to show the formatted duration next to the task start and update times, improving visibility of how long each task took. [[1]](diffhunk://#diff-2c02092d6277716c53a561b7b5819d77f6e4a7094d208c638d9a6e3099491590R172-R176) [[2]](diffhunk://#diff-2c02092d6277716c53a561b7b5819d77f6e4a7094d208c638d9a6e3099491590R280-R284)