### PR TITLE
fix: Return empty list when no auth is enabled

### DIFF
--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -13,8 +13,8 @@ async def list_connectors(request: Request, connector_service, session_manager):
         )
         return JSONResponse({"connectors": connector_types})
     except Exception as e:
-        logger.error("Error listing connectors", error=str(e))
-        return JSONResponse({"error": str(e)}, status_code=500)
+        logger.info("Error listing connectors", error=str(e))
+        return JSONResponse({"connectors": []})
 
 
 async def connector_sync(request: Request, connector_service, session_manager):

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -321,7 +321,7 @@ class ConnectionManager:
 
         return None
 
-    def get_available_connector_types(self) -> Dict[str, Dict[str, str]]:
+    def get_available_connector_types(self) -> Dict[str, Dict[str, Any]]:
         """Get available connector types with their metadata"""
         return {
             "google_drive": {


### PR DESCRIPTION
This pull request makes small improvements to error handling and type definitions related to connector management. The changes aim to provide more consistent API responses and allow for greater flexibility in connector metadata.

- **Error Handling Improvements**
  * The `list_connectors` endpoint now logs errors with `logger.info` instead of `logger.error`, and returns an empty `connectors` list instead of an error message when an exception occurs. This ensures consistent response structure for clients, even in failure cases.

- **Type Definition Update**
  * The return type of `get_available_connector_types` in `connection_manager.py` has been updated from `Dict[str, Dict[str, str]]` to `Dict[str, Dict[str, Any]]`, allowing connector metadata to include values of any type, not just strings.