### PR TITLE
design sweep for chunks page

### DIFF
--- a/frontend/src/app/knowledge/chunks/page.tsx
+++ b/frontend/src/app/knowledge/chunks/page.tsx
@@ -224,7 +224,9 @@ function ChunksPageContent() {
                       <div>
                         <Checkbox
                           checked={selectedChunks.has(index)}
-                          onCheckedChange={(checked) => handleChunkCardCheckboxChange(checked, index)}
+                          onCheckedChange={() =>
+                            handleChunkCardCheckboxChange(index)
+                          }
                         />
                       </div>
                       <span className="text-sm font-bold">


### PR DESCRIPTION
Chunks page card style updates + added the right sidebar
<img width="1215" height="666" alt="Screenshot 2025-09-23 at 11 54 50 AM" src="https://github.com/user-attachments/assets/d04df330-3187-457f-b956-6884a1b0777d" />


Using the search filter (just filters in memory at the moment)
<img width="1682" height="786" alt="Screenshot 2025-09-22 at 2 22 16 PM" src="https://github.com/user-attachments/assets/b84a7e11-983f-4862-9a17-a7951c73cf56" />
