### PR TITLE
fix: make avatar not selectable, disable file drop on chat

### DIFF
--- a/frontend/src/app/chat/page.tsx
+++ b/frontend/src/app/chat/page.tsx
@@ -1941,7 +1941,7 @@ function ChatPage() {
                     {message.role === "user" && (
                       <div className="flex gap-3">
                         <Avatar className="w-8 h-8 flex-shrink-0 select-none">
-                          <AvatarImage src={user?.picture} alt={user?.name} />
+                          <AvatarImage draggable={false} src={user?.picture} alt={user?.name} />
                           <AvatarFallback className="text-sm bg-primary/20 text-primary">
                             {user?.name ? (
                               user.name.charAt(0).toUpperCase()


### PR DESCRIPTION
This pull request removes drag-and-drop document upload functionality from the chat page, streamlining the user interface and related logic. The main changes include deleting all drag event handlers and state, removing drag-over visual cues, and making minor accessibility improvements to avatars.

**Removal of drag-and-drop upload feature:**

* Deleted all drag event handlers (`handleDragEnter`, `handleDragOver`, `handleDragLeave`, `handleDrop`), as well as the related state variables (`isDragOver`, `dragCounterRef`). This removes the ability to drag and drop files into the chat area for upload. [[1]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L123) [[2]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L134) [[3]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L277-L313)
* Removed all conditional UI and overlays that appeared when dragging files over the chat area, including both the empty state and when messages are present. [[1]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L1960-R1926) [[2]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L2085-L2096)

**Minor UI/accessibility improvements:**

* Added `select-none` to user and assistant avatars to prevent text selection on avatar elements, improving user experience. [[1]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L2001-R1943) [[2]](diffhunk://#diff-7a1f0d0a59f90e4e3d9fd5b06ca53a9a351c85103bd90e3107196e62e59e68e7L2021-R1963)