### PR TITLE
fix: turn button inside button into div

### DIFF
--- a/frontend/components/navigation.tsx
+++ b/frontend/components/navigation.tsx
@@ -456,20 +456,24 @@ export function Navigation({
                             </div>
                           </div>
                           <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <button
-                                type="button"
-                                className="opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100 data-[state=open]:text-foreground transition-opacity p-1 hover:bg-accent rounded text-muted-foreground hover:text-foreground ml-2 flex-shrink-0"
+                            <DropdownMenuTrigger disabled={loading || deleteSessionMutation.isPending} asChild>
+                              <div
+                                className="opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100 data-[state=open]:text-foreground transition-opacity p-1 hover:bg-accent rounded text-muted-foreground hover:text-foreground ml-2 flex-shrink-0 cursor-pointer"
                                 title="More options"
-                                disabled={
-                                  loading || deleteSessionMutation.isPending
-                                }
+                                role="button"
+                                tabIndex={0}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                 }}
+                                onKeyDown={(e) => {
+                                  if (e.key === 'Enter' || e.key === ' ') {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                  }
+                                }}
                               >
                                 <EllipsisVertical className="h-4 w-4" />
-                              </button>
+                              </div>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent
                               side="bottom"


### PR DESCRIPTION
This pull request updates the `Navigation` component to improve accessibility and user experience for the dropdown menu trigger. The main change is replacing the trigger button with a `div` that behaves like a button, while ensuring it is still accessible and properly disabled when needed.

**Accessibility and UI improvements:**

* Replaced the `<button>` element with a `<div>` for the dropdown trigger, adding `role="button"` and `tabIndex={0}` to maintain accessibility, and handling keyboard events (`Enter` and `Space`) to mimic button behavior.
* Moved the `disabled` prop to `DropdownMenuTrigger` to ensure the trigger is disabled when loading or when the delete session mutation is pending.