### PR TITLE
docs: Comment for complex password requiremens on OpenSearch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ NUDGES_FLOW_ID=ebc01d31-1976-46ce-a385-b0240327226c
 # container startup from this value. Do not commit real secrets.
 # must match the hashed password in secureconfig, must change for secure deployment!!!
 # NOTE: if you set this by hand, it must be a complex password: 
-# mixed case, numbers, and symbols greater than 10 characters 
+The password must contain at least 8 characters, and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.
 OPENSEARCH_PASSWORD=
 
 # make here https://console.cloud.google.com/apis/credentials


### PR DESCRIPTION
closes #225 with an additional comment in .env.example