### PR TITLE
docs: add docling serve manual start to docker page

### DIFF
--- a/docs/docs/core-components/ingestion.mdx
+++ b/docs/docs/core-components/ingestion.mdx
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 import PartialModifyFlows from '@site/docs/_partial-modify-flows.mdx';
 
 OpenRAG uses [Docling](https://docling-project.github.io/docling/) for its document ingestion pipeline.
-More specifically, OpenRAG uses [Docling Serve](https://github.com/docling-project/docling-serve), which starts a `docling-serve` process on your local machine and runs Docling ingestion through an API service.
+More specifically, OpenRAG uses [Docling Serve](https://github.com/docling-project/docling-serve), which starts a `docling serve` process on your local machine and runs Docling ingestion through an API service.
 
 Docling ingests documents from your local machine or OAuth connectors, splits them into chunks, and stores them as separate, structured documents in the OpenSearch `documents` index.
 
@@ -19,8 +19,8 @@ OpenRAG chose Docling for its support for a wide variety of file formats, high p
 
 These settings configure the Docling ingestion parameters.
 
-OpenRAG will warn you if `docling-serve` is not running.
-To start or stop `docling-serve` or any other native services, in the TUI main menu, click **Start Native Services** or **Stop Native Services**.
+OpenRAG will warn you if `docling serve` is not running.
+To start or stop `docling serve` or any other native services, in the TUI main menu, click **Start Native Services** or **Stop Native Services**.
 
 **Embedding model** determines which AI model is used to create vector embeddings. The default is `text-embedding-3-small`.
 

--- a/docs/docs/get-started/docker.mdx
+++ b/docs/docs/get-started/docker.mdx
@@ -90,9 +90,8 @@ The following values are **required** to be set:
    docker compose up -d
    ```
 
-   For CPU-only systems, run the following commands:
+   For environments without GPU support, run: 
    ```bash
-   docker compose -f docker-compose-cpu.yml build
    docker compose -f docker-compose-cpu.yml up -d
    ```
 

--- a/docs/docs/get-started/tui.mdx
+++ b/docs/docs/get-started/tui.mdx
@@ -51,9 +51,9 @@ If images are missing, the TUI runs `docker compose pull`, then runs `docker com
 ### Start native services
 
 A "native" service in OpenRAG refers to a service run natively on your machine, and not within a container.
-The `docling-serve` process is a native service in OpenRAG, because it's a document processing service that is run on your local machine, and controlled separately from the containers.
+The `docling serve` process is a native service in OpenRAG, because it's a document processing service that is run on your local machine, and controlled separately from the containers.
 
-To start or stop `docling-serve` or any other native services, in the TUI main menu, click **Start Native Services** or **Stop Native Services**.
+To start or stop `docling serve` or any other native services, in the TUI main menu, click **Start Native Services** or **Stop Native Services**.
 
 To view the status, port, or PID of a native service, in the TUI main menu, click [Status](#status).
 


### PR DESCRIPTION
Add this required step for the Docker deployment.
Correct some instances of `docling-serve` to `docling serve`.