### PR TITLE
fix: check if ollama model is embedding by testing it

### DIFF
--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -1,5 +1,6 @@
 import httpx
 from typing import Dict, List
+from api.provider_validation import test_embedding
 from utils.container_utils import transform_localhost_url
 from utils.logging_config import get_logger
 
@@ -171,10 +172,12 @@ class ModelsService:
                         has_tools = TOOL_CALLING_CAPABILITY in capabilities
 
                         # Check if it's an embedding model
-                        is_embedding = any(
-                            embed_model in model_name.lower()
-                            for embed_model in self.OLLAMA_EMBEDDING_MODELS
-                        )
+                        try:
+                            await test_embedding("ollama", endpoint=endpoint, embedding_model=model_name)
+                            is_embedding = True
+                        except Exception as e:
+                            logger.warning(f"Failed to test embedding for model {model_name}: {str(e)}")
+                            is_embedding = False
 
                         if is_embedding:
                             # Embedding models only need completion capability


### PR DESCRIPTION
This pull request updates the logic for detecting embedding models in the `get_ollama_models` function of `models_service.py`. Instead of relying on model name matching, it now uses a runtime validation to determine if a model supports embeddings. This approach is more robust and less error-prone.

**Embedding model detection improvements:**

* Replaced model name substring matching with a call to `test_embedding` to verify embedding capability for Ollama models at runtime, improving accuracy and reliability.
* Added import of `test_embedding` from `api.provider_validation` to support the new embedding detection logic.