### PR TITLE
chore: delete unused models

### DIFF
--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -10,18 +10,6 @@ logger = get_logger(__name__)
 class ModelsService:
     """Service for fetching available models from different AI providers"""
 
-    OLLAMA_EMBEDDING_MODELS = [
-        "nomic-embed-text",
-        "mxbai-embed-large",
-        "snowflake-arctic-embed",
-        "all-minilm",
-        "bge-m3",
-        "bge-large",
-        "paraphrase-multilingual",
-        "granite-embedding",
-        "jina-embeddings-v2-base-en",
-    ]
-
     OPENAI_TOOL_CALLING_MODELS = [
         "gpt-5",
         "gpt-5-mini",


### PR DESCRIPTION
This pull request makes a small change to the `ModelsService` by removing the list of `OLLAMA_EMBEDDING_MODELS`, which defined supported embedding models for the Ollama provider.

* Removed the `OLLAMA_EMBEDDING_MODELS` list from `ModelsService`, cleaning up unused or deprecated model references.