### PR TITLE
fix: changed default llm model to be gpt 4o

### DIFF
--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -64,7 +64,7 @@ class ModelsService:
                             {
                                 "value": model_id,
                                 "label": model_id,
-                                "default": model_id == "gpt-5",
+                                "default": model_id == "gpt-4o",
                             }
                         )
 


### PR DESCRIPTION
This pull request makes a small update to the default OpenAI model selection logic, changing the default model from `gpt-5` to `gpt-4o` in the `get_openai_models` method.