### PR TITLE
docs: add anthropic provider and new onboarding

### DIFF
--- a/docs/docs/_partial-onboarding.mdx
+++ b/docs/docs/_partial-onboarding.mdx
@@ -22,26 +22,22 @@ Choose one LLM provider and complete these steps:
     1. Enable **Get API key from environment variable** to automatically enter your key from the TUI-generated `.env` file.
     Alternatively, paste an OpenAI API key into the field.
     2. Under **Advanced settings**, select your **Language Model**.
-    3. To load 2 sample PDFs, enable **Sample dataset**.
-    This is recommended, but not required.
-    4. Click **Complete**.
-    5. In the second onboarding panel, select a provider for embeddings and select your **Embedding Model**.
-    6. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
+    3. Click **Complete**.
+    4. In the second onboarding panel, select a provider for embeddings and select your **Embedding Model**.
+    5. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
     Alternatively, click <Icon name="ArrowRight" aria-hidden="true"/> **Skip overview**.
-    7. Continue with the [Quickstart](/quickstart).
+    6. Continue with the [Quickstart](/quickstart).
 
     </TabItem>
     <TabItem value="IBM watsonx.ai" label="IBM watsonx.ai">
     1. Complete the fields for **watsonx.ai API Endpoint**, **IBM Project ID**, and **IBM API key**.
     These values are found in your IBM watsonx deployment.
     2. Under **Advanced settings**, select your **Language Model**.
-    3. To load 2 sample PDFs, enable **Sample dataset**.
-    This is recommended, but not required.
-    4. Click **Complete**.
-    5. In the second onboarding panel, select a provider for embeddings and select your **Embedding Model**.
-    6. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
+    3. Click **Complete**.
+    4. In the second onboarding panel, select a provider for embeddings and select your **Embedding Model**.
+    5. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
     Alternatively, click <Icon name="ArrowRight" aria-hidden="true"/> **Skip overview**.
-    7. Continue with the [Quickstart](/quickstart).
+    6. Continue with the [Quickstart](/quickstart).
 
     </TabItem>
     <TabItem value="Anthropic" label="Anthropic">
@@ -51,13 +47,11 @@ Choose one LLM provider and complete these steps:
     1. Enable **Use environment Anthropic API key** to automatically use your key from the TUI-generated `.env` file.
     Alternatively, paste an Anthropic API key into the field.
     2. Under **Advanced settings**, select your **Language Model**.
-    3. To load 2 sample PDFs, enable **Sample dataset**.
-    This is recommended, but not required.
-    4. Click **Complete**.
-    5. In the second onboarding panel, select a provider for embeddings and select your **Embedding Model**.
-    6. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
+    3. Click **Complete**.
+    4. In the second onboarding panel, select a provider for embeddings and select your **Embedding Model**.
+    5. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
     Alternatively, click <Icon name="ArrowRight" aria-hidden="true"/> **Skip overview**.
-    7. Continue with the [Quickstart](/quickstart).
+    6. Continue with the [Quickstart](/quickstart).
 
     </TabItem>
     <TabItem value="Ollama" label="Ollama">
@@ -68,13 +62,11 @@ Choose one LLM provider and complete these steps:
     The default Ollama server address is `http://localhost:11434`.
     OpenRAG automatically transforms `localhost` to access services outside of the container, and sends a test connection to your Ollama server to confirm connectivity.
     2. Under **Advanced settings**, select your **Language Model** from the models available on your Ollama server.
-    3. To load 2 sample PDFs, enable **Sample dataset**.
-    This is recommended, but not required.
-    4. Click **Complete**.
-    5. In the second onboarding panel, select your **Embedding Model** from the models available on your Ollama server.
-    6. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
+    3. Click **Complete**.
+    4. In the second onboarding panel, select your **Embedding Model** from the models available on your Ollama server.
+    5. To complete the onboarding tasks, click **What is OpenRAG**, and then click **Add a Document**.
     Alternatively, click <Icon name="ArrowRight" aria-hidden="true"/> **Skip overview**.
-    7. Continue with the [Quickstart](/quickstart).
+    6. Continue with the [Quickstart](/quickstart).
 
     </TabItem>
     </Tabs>


### PR DESCRIPTION
[Preview](https://d5rxiv0do0q3v.cloudfront.net/langflow-drafts/docs-add-anthropic-provider/install#application-onboarding)
* Add anthropic provider, and specify that anthropic does not have embedding models.
* Specify that users can now select different embedding and language model providers.
* Update onboarding steps to follow this flow.