### PR TITLE
fix: make background on onboarding depend on light and dark mode, fixed border color

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -9,6 +9,7 @@
     --font-chivo: "Chivo", sans-serif;
 
     /* Core Theme Colors */
+    --onboarding-background: 240 5% 96%;
     --background: 0 0% 100%;
     --foreground: 0 0% 0%;
     --card: 0 0% 100%;
@@ -56,6 +57,7 @@
   }
 
   .dark {
+    --onboarding-background: 0 0% 0%;
     --background: 240 6% 10%;
     --foreground: 0 0% 100%;
     --card: 240 6% 10%;

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} ${chivo.variable} antialiased h-lvh w-full overflow-hidden bg-black`}
+        className={`${inter.variable} ${jetbrainsMono.variable} ${chivo.variable} antialiased h-lvh w-full overflow-hidden bg-onboarding-background`}
       >
         <ThemeProvider
           attribute="class"

--- a/frontend/src/components/chat-renderer.tsx
+++ b/frontend/src/components/chat-renderer.tsx
@@ -143,7 +143,7 @@ export function ChatRenderer({
 					animate={{
 						width: showLayout ? "100%" : "850px",
 						borderRadius: showLayout ? "0" : "16px",
-						border: showLayout ? "0" : "1px solid #27272A",
+						border: showLayout ? "0" : "1px solid hsl(var(--border))",
 						height: showLayout ? "100%" : "800px",
 						x: x,
 						y: y,

--- a/frontend/src/components/layout-wrapper.tsx
+++ b/frontend/src/components/layout-wrapper.tsx
@@ -3,108 +3,108 @@
 import { usePathname } from "next/navigation";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import {
-  DoclingHealthBanner,
-  useDoclingHealth,
+	DoclingHealthBanner,
+	useDoclingHealth,
 } from "@/components/docling-health-banner";
-import {
-  ProviderHealthBanner,
-  useProviderHealth,
-} from "@/components/provider-health-banner";
 import { KnowledgeFilterPanel } from "@/components/knowledge-filter-panel";
+import {
+	ProviderHealthBanner,
+	useProviderHealth,
+} from "@/components/provider-health-banner";
 import { TaskNotificationMenu } from "@/components/task-notification-menu";
 import { useAuth } from "@/contexts/auth-context";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { useTask } from "@/contexts/task-context";
 import { cn } from "@/lib/utils";
+import { AnimatedConditional } from "./animated-conditional";
 import { ChatRenderer } from "./chat-renderer";
 import AnimatedProcessingIcon from "./ui/animated-processing-icon";
-import { AnimatedConditional } from "./animated-conditional";
 
 export function LayoutWrapper({ children }: { children: React.ReactNode }) {
-  const pathname = usePathname();
-  const { isMenuOpen } = useTask();
-  const { isPanelOpen } = useKnowledgeFilter();
-  const { isLoading, isAuthenticated, isNoAuthMode } = useAuth();
+	const pathname = usePathname();
+	const { isMenuOpen } = useTask();
+	const { isPanelOpen } = useKnowledgeFilter();
+	const { isLoading, isAuthenticated, isNoAuthMode } = useAuth();
 
-  // List of paths that should not show navigation
-  const authPaths = ["/login", "/auth/callback"];
-  const isAuthPage = authPaths.includes(pathname);
+	// List of paths that should not show navigation
+	const authPaths = ["/login", "/auth/callback"];
+	const isAuthPage = authPaths.includes(pathname);
 
-  // Call all hooks unconditionally (React rules)
-  // But disable queries for auth pages to prevent unnecessary requests
-  const { data: settings, isLoading: isSettingsLoading } = useGetSettingsQuery({
-    enabled: !isAuthPage && (isAuthenticated || isNoAuthMode),
-  });
+	// Call all hooks unconditionally (React rules)
+	// But disable queries for auth pages to prevent unnecessary requests
+	const { data: settings, isLoading: isSettingsLoading } = useGetSettingsQuery({
+		enabled: !isAuthPage && (isAuthenticated || isNoAuthMode),
+	});
 
-  const { isUnhealthy: isDoclingUnhealthy } = useDoclingHealth();
-  const { isUnhealthy: isProviderUnhealthy } = useProviderHealth();
+	const { isUnhealthy: isDoclingUnhealthy } = useDoclingHealth();
+	const { isUnhealthy: isProviderUnhealthy } = useProviderHealth();
 
-  // For auth pages, render immediately without navigation
-  // This prevents the main layout from flashing
-  if (isAuthPage) {
-    return <div className="h-full">{children}</div>;
-  }
+	// For auth pages, render immediately without navigation
+	// This prevents the main layout from flashing
+	if (isAuthPage) {
+		return <div className="h-full">{children}</div>;
+	}
 
-  const isOnKnowledgePage = pathname.startsWith("/knowledge");
+	const isOnKnowledgePage = pathname.startsWith("/knowledge");
 
-  const isSettingsLoadingOrError = isSettingsLoading || !settings;
+	const isSettingsLoadingOrError = isSettingsLoading || !settings;
 
-  // Show loading state when backend isn't ready
-  if (
-    isLoading ||
-    (isSettingsLoadingOrError && (isNoAuthMode || isAuthenticated))
-  ) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background">
-        <div className="flex flex-col items-center gap-4">
-          <AnimatedProcessingIcon className="h-8 w-8 text-current" />
-          <p className="text-muted-foreground">Starting OpenRAG...</p>
-        </div>
-      </div>
-    );
-  }
+	// Show loading state when backend isn't ready
+	if (
+		isLoading ||
+		(isSettingsLoadingOrError && (isNoAuthMode || isAuthenticated))
+	) {
+		return (
+			<div className="min-h-screen flex items-center justify-center bg-background">
+				<div className="flex flex-col items-center gap-4">
+					<AnimatedProcessingIcon className="h-8 w-8 text-current" />
+					<p className="text-muted-foreground">Starting OpenRAG...</p>
+				</div>
+			</div>
+		);
+	}
 
-  // For all other pages, render with Langflow-styled navigation and task menu
-  return (
-    <div className="h-screen w-screen flex items-center justify-center">
-      <div
-        className={cn(
-          "app-grid-arrangement bg-black relative",
-          isPanelOpen && isOnKnowledgePage && !isMenuOpen && "filters-open",
-          isMenuOpen && "notifications-open"
-        )}
-      >
-        <div className="w-full z-10 bg-background [grid-area:banner]">
-          <AnimatedConditional
-            vertical
-            isOpen={isDoclingUnhealthy}
-            className="w-full"
-          >
-            <DoclingHealthBanner />
-          </AnimatedConditional>
-          {settings?.edited && (
-            <AnimatedConditional
-              vertical
-              isOpen={isProviderUnhealthy}
-              className="w-full"
-            >
-              <ProviderHealthBanner />
-            </AnimatedConditional>
-          )}
-        </div>
+	// For all other pages, render with Langflow-styled navigation and task menu
+	return (
+		<div className="h-screen w-screen flex items-center justify-center">
+			<div
+				className={cn(
+					"app-grid-arrangement bg-onboarding-background relative",
+					isPanelOpen && isOnKnowledgePage && !isMenuOpen && "filters-open",
+					isMenuOpen && "notifications-open",
+				)}
+			>
+				<div className="w-full z-10 bg-background [grid-area:banner]">
+					<AnimatedConditional
+						vertical
+						isOpen={isDoclingUnhealthy}
+						className="w-full"
+					>
+						<DoclingHealthBanner />
+					</AnimatedConditional>
+					{settings?.edited && (
+						<AnimatedConditional
+							vertical
+							isOpen={isProviderUnhealthy}
+							className="w-full"
+						>
+							<ProviderHealthBanner />
+						</AnimatedConditional>
+					)}
+				</div>
 
-        <ChatRenderer settings={settings}>{children}</ChatRenderer>
+				<ChatRenderer settings={settings}>{children}</ChatRenderer>
 
-        {/* Task Notifications Panel */}
-        <aside className="overflow-y-auto overflow-x-hidden [grid-area:notifications]">
-          {isMenuOpen && <TaskNotificationMenu />}
-        </aside>
+				{/* Task Notifications Panel */}
+				<aside className="overflow-y-auto overflow-x-hidden [grid-area:notifications]">
+					{isMenuOpen && <TaskNotificationMenu />}
+				</aside>
 
-        {/* Knowledge Filter Panel */}
-        <aside className="overflow-y-auto overflow-x-hidden [grid-area:filters]">
-          {isPanelOpen && <KnowledgeFilterPanel />}
-        </aside>
-      </div>
-    </div>
-  );
+				{/* Knowledge Filter Panel */}
+				<aside className="overflow-y-auto overflow-x-hidden [grid-area:filters]">
+					{isPanelOpen && <KnowledgeFilterPanel />}
+				</aside>
+			</div>
+		</div>
+	);
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -90,6 +90,7 @@ const config = {
         shimmer: "shimmer 3s ease-in-out infinite",
       },
       colors: {
+        "onboarding-background": "hsl(var(--onboarding-background))",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",


### PR DESCRIPTION
This pull request updates the onboarding background color theme across the application for both light and dark modes, ensuring consistent styling and easier theme management. It also improves code organization in the `layout-wrapper` component and standardizes border color usage.

**Theme and Styling Updates:**

* Added new CSS variable `--onboarding-background` for onboarding background color in both light and dark modes in `globals.css`. [[1]](diffhunk://#diff-87958537a79d51d35702beb783d9e8a8aea8d2b455ce6f65fb5e3cce3061318fR12) [[2]](diffhunk://#diff-87958537a79d51d35702beb783d9e8a8aea8d2b455ce6f65fb5e3cce3061318fR60)
* Updated Tailwind configuration to support the new `onboarding-background` color utility.
* Changed background color usage in `RootLayout` and `LayoutWrapper` components to use `bg-onboarding-background` instead of hardcoded black, ensuring consistency with the new theme variable. [[1]](diffhunk://#diff-f3bfc5eb8ab49540cf25bb4422d423fac9a4e15f744eb2e2d3b2e1a1b03e441fL41-R41) [[2]](diffhunk://#diff-f8526dbb308a97808a4ba80de411d7e81cc46065d8389ad4088a4a8d529b2344L72-R74)

**Code Organization and Consistency:**

* Standardized border color in `ChatRenderer` to use the CSS variable `--border` instead of a hardcoded color.
* Improved import order in `layout-wrapper.tsx` for better code readability and maintainability.