### PR TITLE
fix: Make sure we exclude the warmup file ingestion

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -85,6 +85,9 @@ logger.info(
     cuda_version=torch.version.cuda,
 )
 
+# Files to exclude from startup ingestion
+EXCLUDED_INGESTION_FILES = {"warmup_ocr.pdf"}
+
 
 async def wait_for_opensearch():
     """Wait for OpenSearch to be ready with retries"""
@@ -312,11 +315,12 @@ async def ingest_default_documents_when_ready(services):
             )
             return
 
-        # Collect files recursively
+        # Collect files recursively, excluding warmup files
         file_paths = [
             os.path.join(root, fn)
             for root, _, files in os.walk(base_dir)
             for fn in files
+            if fn not in EXCLUDED_INGESTION_FILES
         ]
 
         if not file_paths:

--- a/tests/integration/test_startup_ingest.py
+++ b/tests/integration/test_startup_ingest.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import httpx
 import pytest
 
+# Files to exclude from ingestion (should match src/main.py)
+EXCLUDED_INGESTION_FILES = {"warmup_ocr.pdf"}
+
 
 async def wait_for_ready(client: httpx.AsyncClient, timeout_s: float = 30.0):
     deadline = asyncio.get_event_loop().time() + timeout_s
@@ -29,7 +32,7 @@ def count_files_in_documents() -> int:
     base_dir = Path(os.getcwd()) / "documents"
     if not base_dir.is_dir():
         return 0
-    return sum(1 for _ in base_dir.rglob("*") if _.is_file())
+    return sum(1 for _ in base_dir.rglob("*") if _.is_file() and _.name not in EXCLUDED_INGESTION_FILES)
 
 
 @pytest.mark.parametrize("disable_langflow_ingest", [True, False])


### PR DESCRIPTION
This pull request updates the startup ingestion process to exclude specific files, such as warmup files, from being ingested by default. The exclusion logic is consistently applied in both the application and the integration tests to ensure accuracy and prevent unintended files from being processed.

**Startup ingestion improvements:**

* Introduced the `EXCLUDED_INGESTION_FILES` set in `src/main.py` to specify files (e.g., `warmup_ocr.pdf`) that should be excluded from ingestion during startup.
* Updated the file collection logic in `ingest_default_documents_when_ready` to skip files listed in `EXCLUDED_INGESTION_FILES`.

**Testing consistency:**

* Added the same `EXCLUDED_INGESTION_FILES` set to `tests/integration/test_startup_ingest.py` to mirror the application's exclusion logic.
* Modified the `count_files_in_documents` test helper to exclude files in `EXCLUDED_INGESTION_FILES` from its count, ensuring test accuracy.