### PR TITLE
fix: add sonner styling for light mode

### DIFF
--- a/frontend/components/ui/sonner.tsx
+++ b/frontend/components/ui/sonner.tsx
@@ -16,11 +16,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
         classNames: {
           toast:
             "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
-          description: "group-[.toast]:text-muted-foreground",
+          description: "!text-muted-foreground",
           actionButton:
-            "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
+            "!bg-primary !text-primary-foreground",
           cancelButton:
-            "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+            "!bg-muted !text-muted-foreground",
         },
       }}
       {...props}


### PR DESCRIPTION
This pull request makes a small update to the `Toaster` component's styling. The change ensures that the `description`, `actionButton`, and `cancelButton` elements always use the intended color classes by applying utility class overrides.

- Updated the `classNames` in the `Toaster` component (`sonner.tsx`) to use utility class overrides (`!` prefix) for `description`, `actionButton`, and `cancelButton`, ensuring consistent styling regardless of parent group classes.

Closes #411 