### PR TITLE
fix: show uploading spinner on files

### DIFF
--- a/frontend/app/chat/_components/chat-input.tsx
+++ b/frontend/app/chat/_components/chat-input.tsx
@@ -350,6 +350,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
                     onClear={() => {
                       onFileSelected(null);
                     }}
+                    isUploading={isUploading}
                   />
                 </motion.div>
               )}

--- a/frontend/app/chat/_components/file-preview.tsx
+++ b/frontend/app/chat/_components/file-preview.tsx
@@ -1,10 +1,11 @@
-import { X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 
 interface FilePreviewProps {
   uploadedFile: File;
   onClear: () => void;
+  isUploading?: boolean;
 }
 
 const formatFileSize = (bytes: number): string => {
@@ -22,12 +23,14 @@ const getFilePreviewUrl = (file: File): string => {
   return "";
 };
 
-export const FilePreview = ({ uploadedFile, onClear }: FilePreviewProps) => {
+export const FilePreview = ({ uploadedFile, onClear, isUploading = false }: FilePreviewProps) => {
   return (
     <div className="max-w-[250px] flex items-center gap-2 p-2 bg-muted rounded-lg">
       {/* File Image Preview */}
       <div className="flex-shrink-0 w-8 h-8 bg-background rounded border border-input flex items-center justify-center overflow-hidden">
-        {getFilePreviewUrl(uploadedFile) ? (
+        {isUploading ? (
+          <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+        ) : getFilePreviewUrl(uploadedFile) ? (
           <Image
             src={getFilePreviewUrl(uploadedFile)}
             alt="File preview"


### PR DESCRIPTION
This pull request improves the user experience when uploading files in the chat interface by adding a visual indicator during the upload process. The main change is the addition of a loading spinner in the file preview while a file is being uploaded.

**User experience improvements:**

* Added an `isUploading` prop to the `FilePreview` component and displayed a loading spinner (`Loader2`) while a file is uploading, instead of showing the file preview image. [[1]](diffhunk://#diff-24f8a21f2c099f4e5f3a692b5d2a6566641276f2a6c14e8398fae02c8cec55fdL1-R8) [[2]](diffhunk://#diff-24f8a21f2c099f4e5f3a692b5d2a6566641276f2a6c14e8398fae02c8cec55fdL25-R33)
* Passed the `isUploading` state from the `ChatInput` component to the `FilePreview` component to control the display of the loading spinner.

Closes #471 