### PR TITLE
Docs: Known limitation for Windows nested virtualization

### DIFF
--- a/docs/docs/_partial-wsl-install.mdx
+++ b/docs/docs/_partial-wsl-install.mdx
@@ -10,7 +10,7 @@
 
    :::warning Known limitation
    OpenRAG isn't compatible with nested virtualization, which can cause networking issues.
-   Don't install OpenRAG in on a WSL distribution that is installed inside a Windows VM.
+   Don't install OpenRAG on a WSL distribution that is installed inside a Windows VM.
    Instead, install OpenRAG on your base OS or a non-nested Linux VM.
    :::
 
@@ -22,4 +22,4 @@
 
 5. Install and run OpenRAG from within your WSL Ubuntu distribution.
 <br/>
-If you encounter issues with port forwarding or the Windows Firewall, you might need to adjust the [Hyper-V firewall settings](https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/hyper-v-firewall) to allow communication between your WSL distribution and the Windows host. For more troubleshooting advice for networking issues, see [Troubleshooting WLS common issues](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting#common-issues).
+If you encounter issues with port forwarding or the Windows Firewall, you might need to adjust the [Hyper-V firewall settings](https://learn.microsoft.com/en-us/windows/security/operating-system-security/network-security/windows-firewall/hyper-v-firewall) to allow communication between your WSL distribution and the Windows host. For more troubleshooting advice for networking issues, see [Troubleshooting WSL common issues](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting#common-issues).


### PR DESCRIPTION
Add a note about a known limitation regarding Windows nested virtualization (a Windows VM running a WSL distribution + Docker Desktop with OpenRAG).

I think nested virtualization is the correct term here because WSL involves the hypervisor.

To view the preview:

1. Scroll to the last github-actions comment on this PR.
2. Click the View draft link.
3. Go to the quickstart or either install page.
4. In the Prerequisites, expand the Windows WSL collapsible.