### PR TITLE
[DO-NOT-MERGE] trouble shoot build problem of opensearch-arm64

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -55,7 +55,8 @@ jobs:
             tag: langflowai/openrag-opensearch
             platform: linux/arm64
             arch: arm64
-            runs-on: [self-hosted, linux, ARM64, langflow-ai-arm64-2]
+            runs-on: RagRunner
+            # runs-on: [self-hosted, linux, ARM64, langflow-ai-arm64-2]
 
     runs-on: ${{ matrix.runs-on }}
 


### PR DESCRIPTION
Error https://github.com/langflow-ai/openrag/actions/runs/19656161250/job/56408037519

# Fails on `runs-on: [self-hosted, linux, ARM64, langflow-ai-arm64-2]`
```
2025-11-26T04:31:28.0569127Z #28 exporting to image
2025-11-26T04:31:28.0569447Z #28 exporting layers done
2025-11-26T04:31:28.0570082Z #28 exporting manifest sha256:940255b1ff600f44851b1a5cac8122fffa05dc9bb70e9a8b07d0657784d9472f done
2025-11-26T04:31:28.0570983Z #28 exporting config sha256:59a97c62ad90def485a74b0f22c97a20343acb033fdefd2a6e1d8916a41a69b7 done
2025-11-26T04:31:28.0571983Z #28 exporting attestation manifest sha256:358ceb77c8ee581cc261d7cb37acdcd515b6e0305d4dc69023e47c1e6eae26e3 0.0s done
2025-11-26T04:31:28.0573113Z #28 exporting manifest list sha256:5408a573cd17e9d82e90c8fed1f3f293be83ce0b3a634fe80659773b3a2969cb done
2025-11-26T04:31:28.0574061Z #28 pushing layers
2025-11-26T04:31:34.2613563Z #28 ...
2025-11-26T04:32:04.9310965Z #28 exporting to image
2025-11-26T04:32:04.9311291Z #28 pushing layers 37.0s done

2025-11-26T04:32:04.9320317Z #28 ERROR: failed to push langflowai/openrag-opensearch:0.1.39-rc2-arm64: unexpected status from PUT request to https://registry-1.docker.io/v2/langflowai/openrag-opensearch/blobs/uploads/8dfceab0-cb83-49ef-b649-fa18438f5d8b?_state=s9zoeICXjunSA2NJurCWOMOcUH9ViqrK-uq7i73JImB7Ik5hbWUiOiJsYW5nZmxvd2FpL29wZW5yYWctb3BlbnNlYXJjaCIsIlVVSUQiOiI4ZGZjZWFiMC1jYjgzLTQ5ZWYtYjY0OS1mYTE4NDM4ZjVkOGIiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjUtMTEtMjZUMDQ6MzE6MjguMjQ5MTYxMzExWiJ9&digest=sha256%3A04189f4b2ac49faedb8e3a65309493fd553d4a94294880fd917141489ac0b46b: 400 Bad request: <html><body><h1>400 Bad request</h1>
2025-11-26T04:32:04.9324733Z Your browser sent an invalid request.
2025-11-26T04:32:04.9325075Z </body></html>
2025-11-26T04:32:04.9327237Z 
2025-11-26T04:32:04.9327242Z 
2025-11-26T04:32:04.9327798Z ------
2025-11-26T04:32:04.9328239Z  > exporting to image:
2025-11-26T04:32:04.9328513Z ------
2025-11-26T04:32:04.9332599Z ERROR: failed to build: failed to solve: failed to push langflowai/openrag-opensearch:0.1.39-rc2-arm64: unexpected status from PUT request to https://registry-1.docker.io/v2/langflowai/openrag-opensearch/blobs/uploads/8dfceab0-cb83-49ef-b649-fa18438f5d8b?_state=s9zoeICXjunSA2NJurCWOMOcUH9ViqrK-uq7i73JImB7Ik5hbWUiOiJsYW5nZmxvd2FpL29wZW5yYWctb3BlbnNlYXJjaCIsIlVVSUQiOiI4ZGZjZWFiMC1jYjgzLTQ5ZWYtYjY0OS1mYTE4NDM4ZjVkOGIiLCJPZmZzZXQiOjAsIlN0YXJ0ZWRBdCI6IjIwMjUtMTEtMjZUMDQ6MzE6MjguMjQ5MTYxMzExWiJ9&digest=sha256%3A04189f4b2ac49faedb8e3a65309493fd553d4a94294880fd917141489ac0b46b: 400 Bad request: <html><body><h1>400 Bad request</h1>
2025-11-26T04:32:04.9336906Z Your browser sent an invalid request.
2025-11-26T04:32:04.9337251Z </body></html>
2025-11-26T04:32:04.9337401Z 
2025-11-26T04:32:04.9337406Z 
2025-11-26T04:32:04.9948656Z ##[error]buildx failed with: </body></html>
```