### PR TITLE
fix: lock ingestion flow so that backup is not generated

### DIFF
--- a/flows/ingestion_flow.json
+++ b/flows/ingestion_flow.json
@@ -5712,6 +5712,7 @@
   "endpoint_name": null,
   "id": "5488df7c-b93f-4f87-a446-b67028bc0813",
   "is_component": false,
+  "locked": true,
   "last_tested_version": "1.7.0.dev19",
   "name": "OpenSearch Ingestion Flow",
   "tags": [


### PR DESCRIPTION
This pull request introduces a small change to the `flows/ingestion_flow.json` file, setting the `locked` property to `true` for the OpenSearch Ingestion Flow. This likely prevents further modifications to the flow configuration.