### PR TITLE
fix: Handle providers in Restore Flow

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -652,10 +652,9 @@ function KnowledgeSourcesPage() {
 				throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 			})
 			.then(() => {
-				// Only reset form values if the API call was successful
+				// Flow restoration is complete - backend already updated flow with current provider/model
+				// Just reset the UI form value for system prompt
 				setSystemPrompt(DEFAULT_AGENT_SETTINGS.system_prompt);
-				// Trigger model update to default model
-				handleModelChange(DEFAULT_AGENT_SETTINGS.llm_model);
 				closeDialog(); // Close after successful completion
 			})
 			.catch((error) => {


### PR DESCRIPTION
This pull request makes a minor adjustment to the system prompt reset logic in the `KnowledgeSourcesPage` component. After a successful API call, the code now only resets the system prompt UI value, without triggering a model update to the default model.

Fixes #523 