### PR TITLE
chore: Update Dockerfile langflow to 1.7.0dev27

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -1,4 +1,4 @@
-FROM langflowai/langflow-nightly:1.7.0.dev21
+FROM langflowai/langflow-nightly:1.7.0.dev27
 
 EXPOSE 7860
 


### PR DESCRIPTION
This pull request updates the base image version in the `Dockerfile.langflow` to ensure the project uses the latest nightly release of Langflow. This change helps keep dependencies up to date and may include important bug fixes or new features.

* Docker configuration:
  * Updated the base image in `Dockerfile.langflow` from `langflow-nightly:1.7.0.dev21` to `langflow-nightly:1.7.0.dev27` to use a newer version of Langflow.