### PR TITLE
fix:un mount error

### DIFF
--- a/src/tui/screens/monitor.py
+++ b/src/tui/screens/monitor.py
@@ -163,7 +163,7 @@ class MonitorScreen(Screen):
         # Clean up docling manager
         if hasattr(self, "docling_manager"):
             self.docling_manager.cleanup()
-        super().on_unmount()
+        # Reset follow state (already done in _stop_follow, but ensure clean state)
         self._follow_service = None
         self._logs_buffer = []
 


### PR DESCRIPTION
The issue was that super().on_unmount() was being called, but Textual's Screen class doesn't have an on_unmount method. The on_unmount is an event handler that Textual's framework calls automatically when a widget is unmounted - there's no parent implementation to invoke.