### PR TITLE
fix: Add support for environment API key in onboarding

### DIFF
--- a/frontend/app/onboarding/_components/ollama-onboarding.tsx
+++ b/frontend/app/onboarding/_components/ollama-onboarding.tsx
@@ -17,6 +17,7 @@ export function OllamaOnboarding({
   setIsLoadingModels,
   isEmbedding = false,
   alreadyConfigured = false,
+  existingEndpoint,
 }: {
   setSettings: Dispatch<SetStateAction<OnboardingVariables>>;
   sampleDataset: boolean;
@@ -24,9 +25,10 @@ export function OllamaOnboarding({
   setIsLoadingModels?: (isLoading: boolean) => void;
   isEmbedding?: boolean;
   alreadyConfigured?: boolean;
+  existingEndpoint?: string;
 }) {
   const [endpoint, setEndpoint] = useState(
-    alreadyConfigured ? undefined : `http://localhost:11434`,
+    alreadyConfigured ? undefined : (existingEndpoint || `http://localhost:11434`),
   );
   const [showConnecting, setShowConnecting] = useState(false);
   const debouncedEndpoint = useDebouncedValue(endpoint, 500);

--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -518,6 +518,9 @@ const OnboardingCard = ({
                     setIsLoadingModels={setIsLoadingModels}
                     isEmbedding={isEmbedding}
                     alreadyConfigured={providerAlreadyConfigured}
+                    existingEndpoint={currentSettings?.providers?.watsonx?.endpoint}
+                    existingProjectId={currentSettings?.providers?.watsonx?.project_id}
+                    hasEnvApiKey={currentSettings?.providers?.watsonx?.has_api_key === true}
                   />
                 </TabsContent>
                 <TabsContent value="ollama">
@@ -528,6 +531,7 @@ const OnboardingCard = ({
                     setIsLoadingModels={setIsLoadingModels}
                     isEmbedding={isEmbedding}
                     alreadyConfigured={providerAlreadyConfigured}
+                    existingEndpoint={currentSettings?.providers?.ollama?.endpoint}
                   />
                 </TabsContent>
               </Tabs>


### PR DESCRIPTION
Enhanced IBM onboarding to allow using an API key from environment configuration, with UI controls for toggling and validation feedback. Also added support for pre-filling endpoint and project ID for IBM and Ollama providers based on existing settings.

closes #591 , #588 