### PR TITLE
fix: Setup option inaccessible but available

### DIFF
--- a/frontend/components/layout-wrapper.tsx
+++ b/frontend/components/layout-wrapper.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/components/provider-health-banner";
 import { TaskNotificationMenu } from "@/components/task-notification-menu";
 import { useAuth } from "@/contexts/auth-context";
+import { useChat } from "@/contexts/chat-context";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { useTask } from "@/contexts/task-context";
 import { cn } from "@/lib/utils";
@@ -27,6 +28,7 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   const { isMenuOpen } = useTask();
   const { isPanelOpen } = useKnowledgeFilter();
   const { isLoading, isAuthenticated, isNoAuthMode } = useAuth();
+  const { isOnboardingComplete } = useChat();
 
   // List of paths that should not show navigation
   const authPaths = ["/login", "/auth/callback"];
@@ -91,17 +93,17 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
             isOpen={isDoclingUnhealthy}
             className="w-full"
           >
-            <DoclingHealthBanner />
+          <DoclingHealthBanner />
+        </AnimatedConditional>
+        {settings?.edited && isOnboardingComplete && (
+          <AnimatedConditional
+            vertical
+            isOpen={isProviderUnhealthy}
+            className="w-full"
+          >
+            <ProviderHealthBanner />
           </AnimatedConditional>
-          {settings?.edited && (
-            <AnimatedConditional
-              vertical
-              isOpen={isProviderUnhealthy}
-              className="w-full"
-            >
-              <ProviderHealthBanner />
-            </AnimatedConditional>
-          )}
+        )}
         </div>
 
         <ChatRenderer settings={settings}>{children}</ChatRenderer>


### PR DESCRIPTION
This pull request updates the `LayoutWrapper` component to ensure that the provider health banner is only shown after the user has completed onboarding. The main change is the addition of an onboarding completion check using the `isOnboardingComplete` flag from the chat context.

**Onboarding logic improvements:**

* Added `useChat` import and integrated `isOnboardingComplete` flag from `chat-context` to the `LayoutWrapper` component. [[1]](diffhunk://#diff-dc76b6c795a9d1d2bd6c1e2363850cce9a0a6e094014ed1e680daba8ff11b4d2R18) [[2]](diffhunk://#diff-dc76b6c795a9d1d2bd6c1e2363850cce9a0a6e094014ed1e680daba8ff11b4d2R31)
* Updated the conditional rendering of the provider health banner so it only appears if `settings.edited` is true and onboarding is complete (`isOnboardingComplete`).