### PR TITLE
fix: Support for txt file processing outside of Docling

### DIFF
--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -197,10 +197,27 @@ class TaskProcessor:
             file_hash=file_hash,
         )
 
-        # Convert and extract
-        result = clients.converter.convert(file_path)
-        full_doc = result.document.export_to_dict()
-        slim_doc = extract_relevant(full_doc)
+        # Check if this is a .txt file - use simple processing instead of docling
+        import os
+        file_ext = os.path.splitext(file_path)[1].lower()
+        
+        if file_ext == '.txt':
+            # Simple text file processing without docling
+            from utils.document_processing import process_text_file
+            logger.info(
+                "Processing as plain text file (bypassing docling)",
+                file_path=file_path,
+                file_hash=file_hash,
+            )
+            slim_doc = process_text_file(file_path)
+            # Override filename with original_filename if provided
+            if original_filename:
+                slim_doc["filename"] = original_filename
+        else:
+            # Convert and extract using docling for other file types
+            result = clients.converter.convert(file_path)
+            full_doc = result.document.export_to_dict()
+            slim_doc = extract_relevant(full_doc)
 
         texts = [c["text"] for c in slim_doc["chunks"]]
 

--- a/src/utils/document_processing.py
+++ b/src/utils/document_processing.py
@@ -119,6 +119,82 @@ def get_worker_converter():
     return _worker_converter
 
 
+def process_text_file(file_path: str) -> dict:
+    """
+    Process a plain text file without using docling.
+    Returns the same structure as extract_relevant() for consistency.
+    
+    Args:
+        file_path: Path to the .txt file
+        
+    Returns:
+        dict with keys: id, filename, mimetype, chunks
+    """
+    import os
+    from utils.hash_utils import hash_id
+    
+    # Read the file
+    with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+        content = f.read()
+    
+    # Compute hash
+    file_hash = hash_id(file_path)
+    filename = os.path.basename(file_path)
+    
+    # Split content into chunks of ~1000 characters to match typical docling chunk sizes
+    # This ensures embeddings stay within reasonable token limits
+    chunk_size = 1000
+    chunks = []
+    
+    # Split by paragraphs first (double newline)
+    paragraphs = content.split('\n\n')
+    current_chunk = ""
+    chunk_index = 0
+    
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+            
+        # If adding this paragraph would exceed chunk size, save current chunk
+        if len(current_chunk) + len(para) + 2 > chunk_size and current_chunk:
+            chunks.append({
+                "page": chunk_index + 1,  # Use chunk_index + 1 as "page" number
+                "type": "text",
+                "text": current_chunk.strip()
+            })
+            chunk_index += 1
+            current_chunk = para
+        else:
+            if current_chunk:
+                current_chunk += "\n\n" + para
+            else:
+                current_chunk = para
+    
+    # Add the last chunk if any
+    if current_chunk.strip():
+        chunks.append({
+            "page": chunk_index + 1,
+            "type": "text",
+            "text": current_chunk.strip()
+        })
+    
+    # If no chunks were created (empty file), create a single empty chunk
+    if not chunks:
+        chunks.append({
+            "page": 1,
+            "type": "text",
+            "text": ""
+        })
+    
+    return {
+        "id": file_hash,
+        "filename": filename,
+        "mimetype": "text/plain",
+        "chunks": chunks,
+    }
+
+
 def extract_relevant(doc_dict: dict) -> dict:
     """
     Given the full export_to_dict() result:


### PR DESCRIPTION
This pull request adds specialized handling for plain text (`.txt`) files to improve processing efficiency and reliability. Instead of using the more complex `docling` document converter for all file types, `.txt` files are now processed with a lightweight, custom method. This change affects both the main document processing pipeline and the context extraction for chat uploads, ensuring consistent and efficient treatment of text files.

Key changes include:

**Plain text file processing improvements:**

* Added a new `process_text_file` function in `utils/document_processing.py` to handle `.txt` files without using `docling`, splitting content into reasonable chunks for embedding and maintaining compatibility with the existing document structure.
* Updated `process_document_standard` in `models/processors.py` to detect `.txt` files and process them with the new function, while other file types continue to use `docling`.
* Modified `process_upload_context` in `services/document_service.py` to process `.txt` uploads directly and return their full content for chat context, bypassing chunking and page logic used for other formats.

**Codebase consistency and imports:**

* Added necessary `os` imports in relevant files to support file extension checks and path manipulations.