### PR TITLE
fix: Configurable ingestion timeout limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,14 @@
 # Set to true to disable Langflow ingestion and use traditional OpenRAG processor
 # If unset or false, Langflow pipeline will be used (default: upload -> ingest -> delete)
 DISABLE_INGEST_WITH_LANGFLOW=false
+
+# Langflow HTTP timeout configuration (in seconds)
+# For large documents (300+ pages), ingestion can take 30+ minutes
+# Increase these values if you experience timeouts with very large PDFs
+# Default: 2400 seconds (40 minutes) total timeout, 30 seconds connection timeout
+# LANGFLOW_TIMEOUT=2400
+# LANGFLOW_CONNECT_TIMEOUT=30
+
 # make one like so https://docs.langflow.org/api-keys-and-authentication#langflow-secret-key
 LANGFLOW_SECRET_KEY=
 


### PR DESCRIPTION
This pull request adds configurable timeout settings for the Langflow HTTP client to better handle ingestion of large documents, such as PDFs with 300+ pages. The changes allow users to adjust timeout values via environment variables and apply these settings throughout the codebase to minimize timeouts during lengthy ingestion processes.

**Langflow Timeout Configuration:**

* Added `LANGFLOW_TIMEOUT` and `LANGFLOW_CONNECT_TIMEOUT` environment variables to `.env.example` for customizing total and connection timeouts for Langflow operations.
* Updated `src/config/settings.py` to read these environment variables and set default values (`LANGFLOW_TIMEOUT` to 2400 seconds and `LANGFLOW_CONNECT_TIMEOUT` to 30 seconds).

**Langflow HTTP Client Initialization:**

* Modified the Langflow HTTP client initialization in `src/config/settings.py` to use the new timeout configuration, ensuring extended timeouts for large document ingestion. This includes setting explicit values for total, connect, read, write, and pool timeouts.