### PR TITLE
fix: remove adding to failed tasks to fix failed tasks count

### DIFF
--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -257,9 +257,13 @@ class TaskService:
                         import traceback
 
                         traceback.print_exc()
-                        file_task.status = TaskStatus.FAILED
-                        file_task.error = str(e)
-                        upload_task.failed_files += 1
+                        # Note: Processors already handle incrementing failed_files and
+                        # setting file_task status/error, so we don't duplicate that here.
+                        # Only update timestamp if processor didn't already set it
+                        if file_task.status == TaskStatus.RUNNING:
+                            file_task.status = TaskStatus.FAILED
+                        if not file_task.error:
+                            file_task.error = str(e)
                     finally:
                         file_task.updated_at = time.time()
                         upload_task.processed_files += 1


### PR DESCRIPTION
This pull request makes a small improvement to the error handling logic in the `process_with_semaphore` function. The change ensures that the `failed_files` counter and error status are not duplicated, relying on the processor to handle these updates where appropriate. The only update in this pull request is a clarification and minor adjustment to error handling and status updates. 

- Improved error handling to avoid duplicating updates to `failed_files` and `file_task` status/error, only setting them if the processor hasn't already done so (`src/services/task_service.py`).


Closes #532 