### PR TITLE
fix: Better debugging for input type ingest failures

### DIFF
--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -180,6 +180,22 @@ class LangflowFileService:
                 body=resp.text[:1000],
             )
         resp.raise_for_status()
+        
+        # Check if response is actually JSON before parsing
+        content_type = resp.headers.get("content-type", "")
+        if "application/json" not in content_type:
+            logger.error(
+                "[LF] Unexpected response content type from Langflow",
+                content_type=content_type,
+                status_code=resp.status_code,
+                body=resp.text[:1000],
+            )
+            raise ValueError(
+                f"Langflow returned {content_type} instead of JSON. "
+                f"This may indicate the ingestion flow failed or the endpoint is incorrect. "
+                f"Response preview: {resp.text[:500]}"
+            )
+        
         try:
             resp_json = resp.json()
         except Exception as e:


### PR DESCRIPTION
This pull request adds a safeguard to the ingestion flow in `langflow_file_service.py` to ensure the service only attempts to parse valid JSON responses from Langflow. This helps prevent errors and provides clearer error messages when the endpoint returns an unexpected format.

**Error handling improvements:**

* Added a check for the `content-type` header to verify that the response from Langflow is JSON before attempting to parse it, and logs an error and raises a descriptive exception if the content type is not as expected.