### PR TITLE
fix: Add other model provider keys as examples, grouped AWS with other OAuth credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,14 @@ WATSONX_API_KEY=
 WATSONX_ENDPOINT=
 WATSONX_PROJECT_ID=
 
+# LLM Provider configuration. Providers can be "anthropic", "watsonx", "ibm" or "ollama".
+LLM_PROVIDER=
+LLM_MODEL=
+
+# Embedding provider configuration. Providers can be "watsonx", "ibm" or "ollama".
+EMBEDDING_PROVIDER=
+EMBEDDING_MODEL=
+
 # OPTIONAL url for openrag link to langflow in the UI
 LANGFLOW_PUBLIC_URL=
 


### PR DESCRIPTION
This pull request updates the `.env.example` file to improve clarity and expand support for different model providers. The main changes include reorganizing AWS credential entries, adding placeholders for several new model provider API keys, and clarifying comments for configuration.

Environment variable improvements:

* Moved `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to a new section with a clarifying comment about S3 access.
* Added placeholders for new model provider API keys and endpoints: `ANTHROPIC_API_KEY`, `OLLAMA_ENDPOINT`, `WATSONX_API_KEY`, `WATSONX_ENDPOINT`, and `WATSONX_PROJECT_ID`.
* Added section comments to clearly separate AWS credentials, model provider keys, and other configuration variables.

Closes #533 
Closes #614