### PR TITLE
fix: Disambiguate the key error messages

### DIFF
--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -351,6 +351,7 @@ class ModelsService:
                 if text_response.status_code == 200:
                     text_data = text_response.json()
                     text_models = text_data.get("resources", [])
+                    logger.info(f"Retrieved {len(text_models)} text chat models from Watson API")
 
                     for i, model in enumerate(text_models):
                         model_id = model.get("model_id", "")
@@ -363,6 +364,11 @@ class ModelsService:
                                 "default": i == 0,  # First model is default
                             }
                         )
+                else:
+                    logger.warning(
+                        f"Failed to retrieve text chat models. Status: {text_response.status_code}, "
+                        f"Response: {text_response.text[:200]}"
+                    )
 
                 # Fetch embedding models
                 embed_params = {
@@ -379,6 +385,7 @@ class ModelsService:
                 if embed_response.status_code == 200:
                     embed_data = embed_response.json()
                     embed_models = embed_data.get("resources", [])
+                    logger.info(f"Retrieved {len(embed_models)} embedding models from Watson API")
 
                     for i, model in enumerate(embed_models):
                         model_id = model.get("model_id", "")
@@ -391,6 +398,11 @@ class ModelsService:
                                 "default": i == 0,  # First model is default
                             }
                         )
+                else:
+                    logger.warning(
+                        f"Failed to retrieve embedding models. Status: {embed_response.status_code}, "
+                        f"Response: {embed_response.text[:200]}"
+                    )
 
             # Lightweight validation: API key is already validated by successfully getting bearer token
             # No need to make a generation request that consumes credits
@@ -400,7 +412,15 @@ class ModelsService:
                 logger.warning("No bearer token available - API key validation may have failed")
 
             if not language_models and not embedding_models:
-                raise Exception("No IBM models retrieved from API")
+                # Provide more specific error message about missing models
+                error_msg = (
+                    "API key is valid, but no models are available. "
+                    "This usually means your Watson Machine Learning (WML) project is not properly configured. "
+                    "Please ensure: (1) Your watsonx.ai project is associated with a WML service instance, "
+                    "and (2) The project has access to foundation models. "
+                    "Visit your watsonx.ai project settings to configure the WML service association."
+                )
+                raise Exception(error_msg)
 
             return {
                 "language_models": language_models,


### PR DESCRIPTION
This pull request improves error handling and logging in the `get_ibm_models` function within `src/services/models_service.py`. The main focus is to provide clearer feedback when retrieving IBM Watson models, making it easier to diagnose configuration issues and API failures.

Logging and error handling improvements:

* Added info-level logging to record the number of text chat and embedding models retrieved from the Watson API, aiding in monitoring and debugging. [[1]](diffhunk://#diff-0691da6b7b77ba47368b058aec74ef9cbc83dcdeb70a9e195243678f4b0fe1e6R354) [[2]](diffhunk://#diff-0691da6b7b77ba47368b058aec74ef9cbc83dcdeb70a9e195243678f4b0fe1e6R388)
* Added warning-level logging when retrieval of text chat or embedding models fails, including status codes and truncated response bodies for easier troubleshooting. [[1]](diffhunk://#diff-0691da6b7b77ba47368b058aec74ef9cbc83dcdeb70a9e195243678f4b0fe1e6R367-R371) [[2]](diffhunk://#diff-0691da6b7b77ba47368b058aec74ef9cbc83dcdeb70a9e195243678f4b0fe1e6R401-R405)
* Enhanced the exception message when no models are retrieved, providing specific guidance on how to resolve common configuration issues with Watson Machine Learning projects.