### PR TITLE
fix: Handle legacy TUI config directory cleanup in factory reset

### DIFF
--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -79,6 +79,7 @@ class EnvConfig:
     openrag_config_path: str = "$HOME/.openrag/config"
     openrag_data_path: str = "$HOME/.openrag/data"  # Backend data (conversations, tokens, etc.)
     opensearch_data_path: str = "$HOME/.openrag/data/opensearch-data"
+    openrag_tui_config_path_legacy: str = "$HOME/.openrag/tui/config"
     
     # Container version (linked to TUI version)
     openrag_version: str = ""

--- a/src/tui/screens/monitor.py
+++ b/src/tui/screens/monitor.py
@@ -502,6 +502,16 @@ class MonitorScreen(Screen):
                     # Recreate empty config directory
                     config_path.mkdir(parents=True, exist_ok=True)
 
+                # Also delete legacy TUI config folder if it exists (~/.openrag/tui/config/)
+                tui_config_path = expand_path(env_manager.config.openrag_tui_config_path_legacy)
+                if tui_config_path.exists():
+                    success, msg = await self.container_manager.clear_directory_with_container(tui_config_path)
+                    if not success:
+                        # Fallback to regular rmtree if container method fails
+                        shutil.rmtree(tui_config_path)
+                    # Recreate empty config directory
+                    tui_config_path.mkdir(parents=True, exist_ok=True)
+
                 # Delete flow backups only if user chose to (and they actually exist)
                 if self._check_flow_backups():
                     if delete_backups:


### PR DESCRIPTION
Added support for deleting and recreating the legacy TUI config directory (~/.openrag/tui/config/) during the config reset process. This ensures old configuration files are properly removed alongside the current config directory.