### PR TITLE
fix: Follow redirects for OneDrive + SharePoint

### DIFF
--- a/src/connectors/onedrive/connector.py
+++ b/src/connectors/onedrive/connector.py
@@ -394,7 +394,7 @@ class OneDriveConnector(BaseConnector):
             headers = {"Authorization": f"Bearer {token}"}
 
             async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=headers, timeout=60)
+                response = await client.get(url, headers=headers, timeout=60, follow_redirects=True)
                 response.raise_for_status()
                 return response.content
 
@@ -406,7 +406,7 @@ class OneDriveConnector(BaseConnector):
         """Download file content from direct download URL."""
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(download_url, timeout=60)
+                response = await client.get(download_url, timeout=60, follow_redirects=True)
                 response.raise_for_status()
                 return response.content
         except Exception as e:

--- a/src/connectors/sharepoint/connector.py
+++ b/src/connectors/sharepoint/connector.py
@@ -462,7 +462,7 @@ class SharePointConnector(BaseConnector):
             headers = {"Authorization": f"Bearer {token}"}
             
             async with httpx.AsyncClient() as client:
-                response = await client.get(url, headers=headers, timeout=60)
+                response = await client.get(url, headers=headers, timeout=60, follow_redirects=True)
                 response.raise_for_status()
                 return response.content
             
@@ -535,7 +535,7 @@ class SharePointConnector(BaseConnector):
         """Download file content from direct download URL"""
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(download_url, timeout=60)
+                response = await client.get(download_url, timeout=60, follow_redirects=True)
                 response.raise_for_status()
                 return response.content
         except Exception as e:


### PR DESCRIPTION
This pull request updates the file download logic in both the OneDrive and SharePoint connectors to ensure that HTTP redirects are properly followed when downloading files. This makes the connectors more robust when dealing with URLs that redirect to the actual file location.

Improvements to file download handling:

* Updated `src/connectors/onedrive/connector.py` to set `follow_redirects=True` in both `_download_file_content` and `_download_file_from_url` methods, ensuring redirects are followed during file downloads. [[1]](diffhunk://#diff-f5ff94e6782cce480c36f0a1b4b1d14583546f5a118bbe870921f0c949a0a440L397-R397) [[2]](diffhunk://#diff-f5ff94e6782cce480c36f0a1b4b1d14583546f5a118bbe870921f0c949a0a440L409-R409)
* Updated `src/connectors/sharepoint/connector.py` to set `follow_redirects=True` in both `_download_file_content` and `_download_file_from_url` methods, ensuring consistent redirect handling for SharePoint file downloads. [[1]](diffhunk://#diff-63efa4213708fa116f9557500e82b38717978f8b4d7a4407be881a5d14b2fcb7L465-R465) [[2]](diffhunk://#diff-63efa4213708fa116f9557500e82b38717978f8b4d7a4407be881a5d14b2fcb7L538-R538)