### PR TITLE
Bump SDKs to v0.1.2

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag-sdk"
-version = "0.1.1"
+version = "0.1.2"
 description = "Official Python SDK for OpenRAG API"
 readme = "README.md"
 license = "MIT"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrag-sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Official TypeScript/JavaScript SDK for OpenRAG API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
      - Bump Python SDK version from 0.1.1 to 0.1.2
      - Bump TypeScript SDK version from 0.1.1 to 0.1.2