### PR TITLE
Docs: Update note about supported URLs for on-demand chat ingestion

### DIFF
--- a/docs/docs/core-components/ingestion.mdx
+++ b/docs/docs/core-components/ingestion.mdx
@@ -159,12 +159,12 @@ You can [monitor ingestion](#monitor-ingestion) to see the progress of the uploa
 
 When using the OpenRAG chat, you can enter URLs into the chat to be ingested in real-time during your conversation.
 
-:::tip
-Use [UTF-8 encoding](https://www.w3schools.com/tags/ref_urlencode.ASP) for URLs with special characters other than the standard slash, period, and colon characters.
-For example, use `https://en.wikipedia.org/wiki/Caf%C3%A9` instead of `https://en.wikipedia.org/wiki/Café` or `https://en.wikipedia.org/wiki/Coffee%5Fculture` instead of  `https://en.wikipedia.org/wiki/Coffee_culture`.
+:::info
+The chat cannot ingest URLs that end in static document file extensions like `.pdf`.
+To upload these types of files, see [Ingest local files and folders](#ingest-local-files-and-folders) and [Ingest files with OAuth connectors](#oauth-ingestion).
 :::
 
-The **OpenSearch URL Ingestion** flow is used to ingest web content from URLs.
+OpenRAG runs the **OpenSearch URL Ingestion** flow to ingest web content from URLs.
 This flow isn't directly accessible from the OpenRAG user interface.
 Instead, this flow is called by the [**OpenRAG OpenSearch Agent** flow](/chat#flow) as a Model Context Protocol (MCP) tool.
 The agent can call this component to fetch web content from a given URL, and then ingest that content into your OpenSearch knowledge base.


### PR DESCRIPTION
Special characters are allowed, but the extension cannot be a document type like .pdf