### PR TITLE
Add IBM TrustArc cookie consent banner to docs site

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,11 +8,112 @@ import {themes as prismThemes} from 'prism-react-renderer';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const isProduction = process.env.NODE_ENV === 'production';
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'OpenRAG',
   tagline: 'Open Source RAG Platform',
   favicon: 'img/favicon.ico',
+
+  headTags: [
+    ...(isProduction
+      ? [
+          // Google Consent Mode - Set defaults before Google tags load
+          {
+            tagName: "script",
+            attributes: {},
+            innerHTML: `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+
+              // Set default consent to denied
+              gtag('consent', 'default', {
+                'ad_storage': 'denied',
+                'ad_user_data': 'denied',
+                'ad_personalization': 'denied',
+                'analytics_storage': 'denied'
+              });
+            `,
+          },
+          // TrustArc Consent Update Listener
+          {
+            tagName: "script",
+            attributes: {},
+            innerHTML: `
+              (function() {
+                function updateGoogleConsent() {
+                  if (typeof window.truste !== 'undefined' && window.truste.cma) {
+                    var consent = window.truste.cma.callApi('getConsent', window.location.href) || {};
+
+                    // Map TrustArc categories to Google consent types
+                    // Category 0 = Required, 1 = Functional, 2 = Advertising, 3 = Analytics
+                    var hasAdvertising = consent[2] === 1;
+                    var hasAnalytics = consent[3] === 1;
+
+                    gtag('consent', 'update', {
+                      'ad_storage': hasAdvertising ? 'granted' : 'denied',
+                      'ad_user_data': hasAdvertising ? 'granted' : 'denied',
+                      'ad_personalization': hasAdvertising ? 'granted' : 'denied',
+                      'analytics_storage': hasAnalytics ? 'granted' : 'denied'
+                    });
+                  }
+                }
+
+                // Listen for consent changes
+                if (window.addEventListener) {
+                  window.addEventListener('cm_data_subject_consent_changed', updateGoogleConsent);
+                  window.addEventListener('cm_consent_preferences_set', updateGoogleConsent);
+                }
+
+                // Initial check after TrustArc loads
+                if (document.readyState === 'complete') {
+                  updateGoogleConsent();
+                } else {
+                  window.addEventListener('load', updateGoogleConsent);
+                }
+              })();
+            `,
+          },
+          // IBM Analytics Configuration (required for TrustArc)
+          {
+            tagName: "script",
+            attributes: {},
+            innerHTML: `
+              window._ibmAnalytics = {
+                "settings": {
+                  "name": "DataStax",
+                  "tealiumProfileName": "ibm-subsidiary",
+                },
+                "trustarc": {
+                  "privacyPolicyLink": "https://ibm.com/privacy"
+                }
+              };
+              window.digitalData = {
+                "page": {
+                  "pageInfo": {
+                    "ibm": {
+                      "siteId": "IBM_DataStax",
+                    }
+                  },
+                  "category": {
+                    "primaryCategory": "PC230"
+                  }
+                }
+              };
+            `,
+          },
+          // IBM Common Stats Script - loads TrustArc
+          {
+            tagName: "script",
+            attributes: {
+              src: "//1.www.s81c.com/common/stats/ibm-common.js",
+              async: "true",
+            },
+          },
+        ]
+      : []),
+  ],
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
   future: {
@@ -115,6 +216,7 @@ const config = {
               {
                 html: `<div class="footer-links">
                   <span>© ${new Date().getFullYear()} OpenRAG</span>
+                  <span id="preferenceCenterContainer"> ·&nbsp; <a href="#" onclick="if(typeof window !== 'undefined' && window.truste && window.truste.eu && window.truste.eu.clickListener) { window.truste.eu.clickListener(); } return false;" style="cursor: pointer;">Manage Privacy Choices</a></span>
                   </div>`,
               },
             ],


### PR DESCRIPTION
## Summary
- Add IBM TrustArc cookie consent banner to the docs site (production only)
- Implement Google Consent Mode with default deny for all tracking
- Add TrustArc consent listener that updates Google consent based on user choices
- Add "Manage Privacy Choices" footer link to open consent preferences

## Test plan
- [x] Build docs with `npm run build` and serve with `npm run serve`
- [x] Verify TrustArc cookie banner appears on page load
- [x] Verify "Manage Privacy Choices" link in footer opens the consent modal
- [x] Verify consent choices are saved and respected on subsequent visits