### PR TITLE
Docs: Add small API/SDK intro page with links to SDK READMEs

### DIFF
--- a/docs/docs/reference/api-sdk-overview.mdx
+++ b/docs/docs/reference/api-sdk-overview.mdx
@@ -1,0 +1,12 @@
+---
+title: OpenRAG APIs and SDKs
+slug: /reference/api-sdk-overview
+---
+
+You can use OpenRAG's APIs and SDKs to integrate and extend OpenRAG's capabilities:
+
+* [Python SDK](https://github.com/langflow-ai/openrag/tree/main/sdks/python)
+* [TypeScript/JavaScript SDK](https://github.com/langflow-ai/openrag/tree/main/sdks/typescript)
+
+<!-- TBD: MCP: See https://github.com/langflow-ai/openrag/pull/729 -->
+<!-- TBD: API Reference: See https://github.com/langflow-ai/openrag/issues/734 -->

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -75,6 +75,11 @@ const sidebars = {
       label: "Chat",
     },
     "reference/configuration",
+    {
+      type: "doc",
+      id: "reference/api-sdk-overview",
+      label: "APIs and SDKs",
+    },
     "support/contribute",
     "support/troubleshoot",
   ],


### PR DESCRIPTION
Closes #607 (API docs and MCP are TBD and have separate issues)