### PR TITLE
fix: Update Makefile install be

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ install: install-be install-fe
 
 install-be:
 	@echo "📦 Installing backend dependencies..."
-	uv sync --extra torch-cu128
+	uv sync
 
 install-fe:
 	@echo "📦 Installing frontend dependencies..."


### PR DESCRIPTION
This pull request makes a small update to the backend installation process in the `Makefile`. The change removes the explicit installation of the `torch-cu128` extra when syncing backend dependencies, ensuring only the default dependencies are installed.