### PR TITLE
Issue #809: Add configurable hostname and allowed origins for frontend dev server

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ NUDGES_FLOW_ID=ebc01d31-1976-46ce-a385-b0240327226c
 # Set a strong admin password for OpenSearch; a bcrypt hash is generated at
 # container startup from this value. Do not commit real secrets.
 # must match the hashed password in secureconfig, must change for secure deployment!!!
-# NOTE: if you set this by hand, it must be a complex password: 
+# NOTE: if you set this by hand, it must be a complex password:
 # The password must contain at least 8 characters, and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.
 OPENSEARCH_PASSWORD=
 
@@ -86,3 +86,8 @@ LANGFUSE_SECRET_KEY=
 LANGFUSE_PUBLIC_KEY=
 # Leave empty for Langfuse Cloud, or set for self-hosted (e.g., http://localhost:3002)
 LANGFUSE_HOST=
+
+# OPTIONAL: A development-mode only configuration value that allows additional origins (domains/hosts) to make requests to the Next.js dev server (next dev).
+# - A list of comma-separate hostnames may be specified
+# - e.g. http://9.46.110.49:3000,http://10.21.103.227:3000
+NEXT_ALLOWED_DEV_ORIGINS=

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ config/
 opensearch-data/
 
 node_modules
+
+# AI Tools
+/CLAUDE.md
+/.claude

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ ifneq (,$(wildcard .env))
   $(foreach var,$(shell sed -n 's/^\([A-Za-z_][A-Za-z0-9_]*\)=.*/\1/p' .env),$(eval $(var):=$(shell echo $($(var)) | sed "s/^'//;s/'$$//")))
 endif
 
+hostname ?= 0.0.0.0
+
 .PHONY: help dev dev-cpu dev-local infra stop clean build logs shell-backend shell-frontend install \
        test test-integration test-ci test-ci-local test-sdk \
        backend frontend install-be install-fe build-be build-fe logs-be logs-fe logs-lf logs-os \
@@ -123,7 +125,8 @@ backend:
 frontend:
 	@echo "⚛️  Starting frontend locally..."
 	@if [ ! -d "frontend/node_modules" ]; then echo "📦 Installing frontend dependencies first..."; cd frontend && npm install; fi
-	cd frontend && npx next dev
+	cd frontend && npx next dev \
+		--hostname $(hostname)
 
 # Installation
 install: install-be install-fe

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,6 +5,22 @@ import path from "path";
 // Load environment variables from root .env file
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
+function getAllowedDevOrigins(): string[] {
+  const allowedDevOrigins = process.env.NEXT_ALLOWED_DEV_ORIGINS;
+
+  if (!allowedDevOrigins) {
+    // Only the server's own hostname is allowed.
+    // No additional origins.
+    // Explicitly setting an empty array is equivalent to not setting it.
+    return [];
+  }
+
+  return allowedDevOrigins
+    .split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+}
+
 const nextConfig: NextConfig = {
   // Increase timeout for API routes
   experimental: {
@@ -14,6 +30,8 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  // Allow cross-origin requests in development
+  allowedDevOrigins: getAllowedDevOrigins(),
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -63,6 +63,9 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
         "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=20.20.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -120,6 +123,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -136,6 +140,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -152,6 +157,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -168,6 +174,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -216,6 +223,7 @@
         "arm64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -232,6 +240,7 @@
         "x64"
       ],
       "dev": true,
+      "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -241,9 +250,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-      "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -805,6 +814,23 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.9",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
@@ -1213,19 +1239,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.0.tgz",
-      "integrity": "sha512-Fq6DJW+Bb5jaWE69/qOE0D1TUN9+6uWhCeZpdnSBk14pjLcCWR7Q8n49PTSPHazM37JqrsdpEthXy2xn6jWWiA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
       }
     },
     "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
@@ -2474,6 +2487,7 @@
       "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2489,6 +2503,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2499,6 +2514,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2538,6 +2554,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2786,6 +2803,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -5444,6 +5462,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5610,6 +5629,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5619,6 +5639,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6370,6 +6391,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6557,6 +6579,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
  - Add NEXT_ALLOWED_DEV_ORIGINS env var to configure cross-origin requests in development mode
  - Add hostname variable to Makefile (defaults to 0.0.0.0) for binding the Next.js dev server to configurable interfaces
  - Add Node.js engine constraint (>=20.20.0) to frontend package.json
  - Add AI tool config files to .gitignore (CLAUDE.md, .claude)

Implements https://github.com/langflow-ai/openrag/issues/809