### PR TITLE
fix: added warnings about OpenRAG built-in flows

### DIFF
--- a/src/tui/widgets/flow_backup_warning_modal.py
+++ b/src/tui/widgets/flow_backup_warning_modal.py
@@ -101,9 +101,11 @@ class FlowBackupWarningModal(ModalScreen[tuple[bool, bool]]):
             yield Label("⚠ Flow Backups Detected", id="title")
             yield Static(
                 f"Flow backups found in your flows/backup directory.\n\n"
-                f"Proceeding with {self.operation} will reset custom flows to defaults.\n"
-                f"Your customizations are backed up in the flows/backup/ directory.\n\n"
-                f"Choose whether to keep or delete the backup files:",
+                f"Proceeding with {self.operation} will reset OpenRAG's built-in flows to their default configuration and discard user-created flows.\n"
+                f"Your customizations to the built-in flows are backed up in the flows/backup/ directory.\n"
+                f"Other user-created flows aren't backed up; you must export these flows to preserve them.\n"
+                f"Learn more: https://docs.langflow.org/concepts-flows-import\n\n"
+                f"Choose whether to keep or delete the backup files of the built-in flows:",
                 id="message"
             )
             with Vertical(id="checkbox-container"):

--- a/src/tui/widgets/version_mismatch_warning_modal.py
+++ b/src/tui/widgets/version_mismatch_warning_modal.py
@@ -93,7 +93,8 @@ class VersionMismatchWarningModal(ModalScreen[bool]):
                 f"Starting services will update containers to version {self.tui_version}.\n"
                 f"This may cause compatibility issues with your flows.\n\n"
                 f"⚠️  Please backup your flows before continuing.\n"
-                f"   Your flows are in ~/.openrag/flows/\n\n"
+                f"   Customizations to OpenRAG built-in flows are backed up in ~/.openrag/flows/backup/\n"
+                f"   Other user created flows are not backed up automatically.\n\n"
                 f"Do you want to continue?",
                 id="message"
             )


### PR DESCRIPTION
This pull request updates user-facing warning messages in the TUI to clarify the backup behavior for OpenRAG flows. The changes make it clear which flows are automatically backed up and which require manual export, helping users avoid accidental data loss.

**Improvements to backup warnings:**

* Updated the flow backup warning modal in `flow_backup_warning_modal.py` to specify that only customizations to built-in flows are automatically backed up, while user-created flows must be exported manually. Added a documentation link for more information.
* Revised the version mismatch warning modal in `version_mismatch_warning_modal.py` to clarify that only customizations to built-in flows are backed up automatically, and other user-created flows are not.

<img width="535" height="428" alt="image" src="https://github.com/user-attachments/assets/8deaa9e5-587a-4444-87c9-ad841b84b285" />

Closes #555 