### PR TITLE
Docs: Podman and Docker are equally recommended.

### DIFF
--- a/docs/docs/_partial-prereq-no-script.mdx
+++ b/docs/docs/_partial-prereq-no-script.mdx
@@ -1,6 +1,6 @@
 * Install [uv](https://docs.astral.sh/uv/getting-started/installation/).
 
-* Install [Podman](https://podman.io/docs/installation) (recommended) or [Docker](https://docs.docker.com/get-docker/).
+* Install [Podman](https://podman.io/docs/installation) or [Docker](https://docs.docker.com/get-docker/).
 
    The OpenRAG team recommends, at minimum, 8 GB of RAM for container VMs.
    However, if you plan to upload large files regularly, more RAM is recommended.

--- a/docs/docs/get-started/docker.mdx
+++ b/docs/docs/get-started/docker.mdx
@@ -123,7 +123,7 @@ The following variables are required or recommended:
 
 3. Deploy the OpenRAG containers locally using the appropriate Docker Compose configuration for your environment:
 
-   * **CPU-only deployment** (default, recommended): If your host machine doesn't have NVIDIA GPU support, use the base `docker-compose.yml` file:
+   * **CPU-only deployment (Default and recommended)**: If your host machine doesn't have NVIDIA GPU support, use the base `docker-compose.yml` file:
 
       ```bash title="Docker"
       docker compose up -d

--- a/docs/docs/get-started/install-uv.mdx
+++ b/docs/docs/get-started/install-uv.mdx
@@ -35,7 +35,7 @@ For other installation methods, see [Select an installation method](/install-opt
 
 There are two ways to install OpenRAG with `uv`:
 
-* [**`uv add`** (Recommended)](#uv-add): Install OpenRAG as a managed dependency in a new or existing `uv` Python project.
+* [**`uv add` (Recommended)**](#uv-add): Install OpenRAG as a managed dependency in a new or existing `uv` Python project.
 This is recommended because it adds OpenRAG to your `pyproject.toml` and lockfile for better management of dependencies and the virtual environment.
 
 * [**`uv pip install`**](#uv-pip-install): Use the [`uv pip` interface](https://docs.astral.sh/uv/pip/) to install OpenRAG into an existing Python project that uses `pip`, `pip-tools`, and `virtualenv` commands.


### PR DESCRIPTION
Remove "recommended" from Podman because Podman and Docker are equally supported.

Fix the style of some other use of "recommended".