### PR TITLE
Docs: Mention that failed task details clear on refresh

### DIFF
--- a/docs/docs/core-components/ingestion.mdx
+++ b/docs/docs/core-components/ingestion.mdx
@@ -198,8 +198,8 @@ Tasks are separated into multiple sections:
 
    Check the **Success** and **Failed** counts for each completed task to determine the overall success rate.
 
-   **Failed** means something went wrong during ingestion, or the task was manually canceled.
-   For more information, see [Troubleshoot ingestion](#troubleshoot-ingestion).
+   **Failed** means [something went wrong during ingestion](#troubleshoot-ingestion), or the task was manually canceled.
+   Details about failed tasks are cleared when you refresh or leave the **Knowledge** page.
 
 For each task, depending on its state, you can find the task ID, start time, duration, number of files processed successfully, number of files that failed, and the number of files enqueued for processing.
 


### PR DESCRIPTION
Until issue #851 is addressed, this PR mentions that the failed task details are erased if you refresh or leave the Knowledge page.