### PR TITLE
Docs: Correct the port numbers, add port mapping troubleshooting, and add manual stop/start commands for TUI-managed containers

### DIFF
--- a/docs/docs/get-started/manage-services.mdx
+++ b/docs/docs/get-started/manage-services.mdx
@@ -47,7 +47,10 @@ For the Docling native service, see [Stop, start, and inspect native services](#
 
 On the TUI's **Status** page, you can stop, start, and restart OpenRAG's container-based services.
 
-When you click **Restart** or **Start Services**, the following processes are triggered:
+<details>
+<summary>How does the TUI start the containers?</summary>
+
+When you click **Restart** or **Start Services** in the TUI, the following processes are triggered:
 
 1. OpenRAG automatically detects your container runtime, and then checks if your machine has compatible GPU support by checking for `CUDA`, `NVIDIA_SMI`, and Docker/Podman runtime support. This check determines which Docker Compose file OpenRAG uses because there are separate Docker Compose files for GPU and CPU deployments.
 
@@ -55,12 +58,25 @@ When you click **Restart** or **Start Services**, the following processes are tr
 
 3. OpenRAG deploys the containers with `docker compose up -d`.
 
+</details>
+
+Alternatively, you can manually run the Docker/Podman commands to stop and start containers.
+Typically, this is only necessary if there is an error preventing the TUI from managing the containers.
+
+* Stop all containers: [`docker compose down`](https://docs.docker.com/reference/cli/docker/compose/down/) or `podman compose down`
+* Start all containers: [`docker compose up -d`](https://docs.docker.com/reference/cli/docker/compose/up/) or `podman compose up -d`
+* Stop one container: `docker stop CONTAINER_ID` or `podman stop CONTAINER_ID`
+* Start one container: `docker start CONTAINER_ID` or `podman start CONTAINER_ID`
+
 </TabItem>
 <TabItem value="env" label="Self-managed services">
 
-Use [`docker compose down`](https://docs.docker.com/reference/cli/docker/compose/down/) and [`docker compose up -d`](https://docs.docker.com/reference/cli/docker/compose/up/).
+For self-managed deployments, run the Docker/Podman commands to stop and start containers:
 
-To stop or start individual containers, use targeted commands like `docker stop CONTAINER_ID` and `docker start CONTAINER_ID`.
+* Stop all containers: [`docker compose down`](https://docs.docker.com/reference/cli/docker/compose/down/) or `podman compose down`
+* Start all containers: [`docker compose up -d`](https://docs.docker.com/reference/cli/docker/compose/up/) or `podman compose up -d`
+* Stop one container: `docker stop CONTAINER_ID` or `podman stop CONTAINER_ID`
+* Start one container: `docker start CONTAINER_ID` or `podman start CONTAINER_ID`
 
 </TabItem>
 </Tabs>

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -70,7 +70,7 @@ Most of these settings can be configured on the OpenRAG **Settings** page or in 
 | `CHUNK_SIZE` | `1000` | Text chunk size for document processing. |
 | `DISABLE_INGEST_WITH_LANGFLOW` | `false` | Disable Langflow ingestion pipeline. |
 | `DOCLING_OCR_ENGINE` | Set by OS | OCR engine for document processing. For macOS, `ocrmac`. For any other OS, `easyocr`. |
-| `DOCLING_SERVE_URL` | `http://**HOST_IP**:5001` | URL for the [Docling Serve instance](/knowledge#select-a-docling-implementation). By default, OpenRAG starts a local `docling serve` process and auto-detects the host. To use your own local or remote Docling Serve instance, set this variable to the full path to the target instance. The service must run on port 5001. |
+| `DOCLING_SERVE_URL` | `http://HOST_IP:5001` | URL for the [Docling Serve instance](/knowledge#select-a-docling-implementation). By default, OpenRAG starts a local `docling serve` process and auto-detects the host. To use your own local or remote Docling Serve instance, set this variable to the full path to the target instance. The service must run on port 5001. |
 | `OCR_ENABLED` | `false` | Enable OCR for image processing. |
 | `OPENRAG_DOCUMENTS_PATH` | `~/.openrag/documents` | The [local documents path](/knowledge#set-the-local-documents-path) for ingestion. |
 | `PICTURE_DESCRIPTIONS_ENABLED` | `false` | Enable picture descriptions. |
@@ -118,8 +118,8 @@ Configure OpenSearch database authentication.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENSEARCH_HOST` | `localhost` | OpenSearch instance host. |
-| `OPENSEARCH_PORT` | `9200` | OpenSearch instance port. |
+| `OPENSEARCH_HOST` | `localhost` | OpenSearch service host. |
+| `OPENSEARCH_PORT` | `9200` | OpenSearch service port. |
 | `OPENSEARCH_USERNAME` | `admin` | OpenSearch administrator username. |
 | `OPENSEARCH_PASSWORD` | Must be set at start up | Required. OpenSearch administrator password. Must adhere to the [OpenSearch password complexity requirements](https://docs.opensearch.org/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password). You must set this directly in the `.env` or in the TUI's [**Basic/Advanced Setup**](/install#setup). |
 

--- a/docs/docs/support/troubleshoot.mdx
+++ b/docs/docs/support/troubleshoot.mdx
@@ -67,14 +67,44 @@ podman machine start
 
 ## Port conflicts
 
-With the default [environment variable](/reference/configuration) values, OpenRAG requires the following ports to be available on the host machine:
+With the default [environment variable](/reference/configuration) configuration, OpenRAG requires the following ports to be available on the host machine:
 
-* 3000: Langflow application
-* 5001: Docling local ingestion service
-* 5601: OpenSearch Dashboards
-* 7860: Docling UI
-* 8000: Docling API
-* 9200: OpenSearch service
+* `3000`: OpenRAG frontend
+* `7860`: Langflow service
+* `8000`: OpenRAG backend
+* `9200`: OpenSearch service
+* `5601`: OpenSearch dashboards
+* `5001`: Docling service
+
+### Map the OpenRAG frontend port
+
+If you need to run the OpenRAG frontend on a different port, you can map the [`openrag-frontend`](https://github.com/langflow-ai/openrag/blob/main/docker-compose.yml#L89) service to a different port in the `docker-compose` file.
+
+For TUI-managed deployments, the `docker-compose` file is located at `~/.openrag/tui`.
+
+For example, the following configuration maps the OpenRAG frontend to `3808` on the host machine:
+
+```yaml
+  openrag-frontend:
+    image: langflowai/openrag-frontend:${OPENRAG_VERSION:-latest}
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    container_name: openrag-frontend
+    depends_on:
+      - openrag-backend
+    environment:
+      - OPENRAG_BACKEND_HOST=openrag-backend
+    ports:
+      - "3808:3000" # Map host port 3808 to container port 3000
+```
+
+You must [restart the containers](/manage-services#stop-and-start-containers) after making this change.
+
+:::tip
+This configuration isn't recommended unless you _must_ maintain a different service on host port 3000.
+If you experience errors or other issues with port mapping, submit an [OpenRAG GitHub issue](https://github.com/langflow-ai/openrag/issues) for additional support.
+:::
 
 ## OCR ingestion fails (easyocr not installed) {#ocr-ingestion-fails-easyocr-not-installed}
 


### PR DESCRIPTION
Closes #856 

* The port numbers were outdated
* Explain how to configure port mapping, but this isn't recommended bc it's not tested
* Add manual Docker/Podman commands to stop/start containers for TUI-managed deployments.