### PR TITLE
fix: stop tasks polling when unnecessary during onboarding.

### DIFF
--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -176,7 +176,7 @@ const OnboardingCard = ({
 
   // Query tasks to track completion
   const { data: tasks } = useGetTasksQuery({
-    enabled: currentStep !== null, // Only poll when onboarding has started
+    enabled: currentStep !== null && !isCompleted, // Only poll when onboarding has started and stop once step is complete
     refetchInterval: currentStep !== null ? 1000 : false, // Poll every 1 second during onboarding
   });
 


### PR DESCRIPTION
I noticed during onboarding that even once documents were ingested the frontend continued to poll the backend for task status. This is unnecessary, keeps the backend server busy when it doesn't need to be and fills the logs with polling. This addition stops the onboarding cards from polling when they are completed.