### PR TITLE
fix: Clear-text storage of sensitive information

### DIFF
--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -387,7 +387,7 @@ class EnvManager:
                 )
                 f.write(f"LANGFLOW_URL_INGEST_FLOW_ID={self._quote_env_value(self.config.langflow_url_ingest_flow_id)}\n")
                 f.write(f"NUDGES_FLOW_ID={self._quote_env_value(self.config.nudges_flow_id)}\n")
-                f.write(f"OPENSEARCH_PASSWORD={self._quote_env_value(self.config.opensearch_password)}\n")
+                # Intentionally do not persist OPENSEARCH_PASSWORD to avoid storing it in clear text on disk.
                 f.write(f"OPENSEARCH_INDEX_NAME={self._quote_env_value(self.config.opensearch_index_name)}\n")
 
                 # Expand $HOME in paths before writing to .env


### PR DESCRIPTION
Potential fix for [https://github.com/langflow-ai/openrag/security/code-scanning/15](https://github.com/langflow-ai/openrag/security/code-scanning/15)

In general, to fix clear-text storage of sensitive information, do not persist the secret in plain text. Either: (a) avoid persisting it entirely and derive or fetch it securely at runtime, or (b) store only an opaque reference (token/ID) and keep the actual secret in a dedicated secret store. Encrypting before storage is another option, but storing the encryption key alongside the ciphertext on the same host often gives limited benefit.

For this specific code, the minimal, functional-preserving change is: stop writing `OPENSEARCH_PASSWORD` into the `.env` file, while still allowing the application to have a password when needed. The class already has `generate_secure_password` and `setup_secure_defaults` that populate `self.config.opensearch_password` if it is missing. We can adjust the logic so that:

1. `setup_secure_defaults` does **not** auto-generate and persist a password when saving the `.env` file. Instead, it only respects an existing value from environment or `.env`.
2. The actual code that needs `OPENSEARCH_PASSWORD` at runtime should either:
   - get it from an existing env var / `.env` (if set), or
   - generate a one-time ephemeral password (not persisted) if none is set.

However, we are constrained to editing only this file and the shown snippets. The concrete fix we can apply here is:
- Stop writing `OPENSEARCH_PASSWORD=...` into the `.env` file in `save_env_file`.
- Optionally annotate where OpenSearch password should be provided (e.g., via external env/secret) instead of being auto-persisted.

This removes the clear-text storage at the flagged sink while keeping the rest of the behavior (generation and in-memory usage) intact.

Concretely:
- In `save_env_file`, remove the `f.write` line for `OPENSEARCH_PASSWORD=...`.
- Leave `generate_secure_password` and `setup_secure_defaults` unchanged (they only operate in memory), as the issue is specifically the disk write.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
