### PR TITLE
Potential fix for code scanning alert no. 10: Clear-text storage of sensitive information

### DIFF
--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -517,7 +517,7 @@ class EnvManager:
 
                 # Langfuse settings (optional)
                 langfuse_vars = [
-                    ("LANGFUSE_SECRET_KEY", self.config.langfuse_secret_key),
+                    # Intentionally do NOT persist LANGFUSE_SECRET_KEY to avoid clear-text storage of secrets.
                     ("LANGFUSE_PUBLIC_KEY", self.config.langfuse_public_key),
                     ("LANGFUSE_HOST", self.config.langfuse_host),
                 ]


### PR DESCRIPTION
Potential fix for [https://github.com/langflow-ai/openrag/security/code-scanning/10](https://github.com/langflow-ai/openrag/security/code-scanning/10)

General fix: Avoid persisting the Langfuse secret key (and similar high-value secrets) to disk in clear text. Instead, either (a) do not store the secret at all and require it from the environment or a secret manager, or (b) store only an opaque reference/token that can be used to look up the secret elsewhere. Encryption-at-rest within the same process without proper key management doesn’t meaningfully improve security, so the safest non-invasive improvement is to stop writing the secret to `.env`.

Best fix here without changing existing functionality too much: change the `.env` writing logic so that `LANGFUSE_SECRET_KEY` is not written into the file, while still allowing LANGFUSE_PUBLIC_KEY and LANGFUSE_HOST to be persisted exactly as before. This keeps most behavior intact: Langfuse config is still stored, but the most sensitive value is no longer leaked to disk. The code elsewhere presumably can still read `LANGFUSE_SECRET_KEY` from the running environment (e.g., pre-set `.env`, real environment variable, or some other configuration source). We’ll implement this by:

- Adjusting the `langfuse_vars` list in `EnvManager.save_env_file` so it excludes `("LANGFUSE_SECRET_KEY", self.config.langfuse_secret_key)`.
- Leaving the rest of the save logic unchanged.

All changes occur within `src/tui/managers/env_manager.py` inside the shown snippet; no new imports or methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
