### PR TITLE
feat: Support for custom API endpoints and OpenAI-compatible providers

### DIFF
--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -14,6 +14,15 @@ logger = get_logger(__name__)
 class OpenAIConfig:
     """OpenAI provider configuration."""
     api_key: str = ""
+    endpoint: str = ""
+    configured: bool = False
+
+
+@dataclass
+class OpenAICompatibleConfig:
+    """Generic OpenAI-compatible provider configuration."""
+    api_key: str = ""
+    endpoint: str = ""
     configured: bool = False
 
 
@@ -44,6 +53,7 @@ class OllamaConfig:
 class ProvidersConfig:
     """All provider configurations."""
     openai: OpenAIConfig
+    openai_compatible: OpenAICompatibleConfig
     anthropic: AnthropicConfig
     watsonx: WatsonXConfig
     ollama: OllamaConfig
@@ -53,6 +63,8 @@ class ProvidersConfig:
         provider_lower = provider.lower()
         if provider_lower == "openai":
             return self.openai
+        elif provider_lower == "openai-compatible":
+            return self.openai_compatible
         elif provider_lower == "anthropic":
             return self.anthropic
         elif provider_lower == "watsonx":
@@ -116,6 +128,7 @@ class OpenRAGConfig:
         return cls(
             providers=ProvidersConfig(
                 openai=OpenAIConfig(**providers_data.get("openai", {})),
+                openai_compatible=OpenAICompatibleConfig(**providers_data.get("openai-compatible", {})),
                 anthropic=AnthropicConfig(**providers_data.get("anthropic", {})),
                 watsonx=WatsonXConfig(**providers_data.get("watsonx", {})),
                 ollama=OllamaConfig(**providers_data.get("ollama", {})),
@@ -166,6 +179,7 @@ class ConfigManager:
         config_data = {
             "providers": {
                 "openai": {},
+                "openai-compatible": {},
                 "anthropic": {},
                 "watsonx": {},
                 "ollama": {},
@@ -183,7 +197,7 @@ class ConfigManager:
 
                 # Merge file config
                 if "providers" in file_config:
-                    for provider in ["openai", "anthropic", "watsonx", "ollama"]:
+                    for provider in ["openai", "openai-compatible", "anthropic", "watsonx", "ollama"]:
                         if provider in file_config["providers"]:
                             config_data["providers"][provider].update(
                                 file_config["providers"][provider]
@@ -224,6 +238,14 @@ class ConfigManager:
         # OpenAI provider settings
         if os.getenv("OPENAI_API_KEY"):
             config_data["providers"]["openai"]["api_key"] = os.getenv("OPENAI_API_KEY")
+        if os.getenv("OPENAI_BASE_URL"):
+            config_data["providers"]["openai"]["endpoint"] = os.getenv("OPENAI_BASE_URL")
+
+        # OpenAI Compatible provider settings
+        if os.getenv("OPENAI_COMPATIBLE_API_KEY"):
+            config_data["providers"]["openai-compatible"]["api_key"] = os.getenv("OPENAI_COMPATIBLE_API_KEY")
+        if os.getenv("OPENAI_COMPATIBLE_BASE_URL"):
+            config_data["providers"]["openai-compatible"]["endpoint"] = os.getenv("OPENAI_COMPATIBLE_BASE_URL")
 
         # Anthropic provider settings
         if os.getenv("ANTHROPIC_API_KEY"):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -100,6 +100,10 @@ OPENAI_EMBEDDING_DIMENSIONS = {
         "text-embedding-ada-002": 1536,
     }
 
+# Valid providers configuration
+VALID_LLM_PROVIDERS = ["openai", "anthropic", "watsonx", "ollama", "openai-compatible"]
+VALID_EMBEDDING_PROVIDERS = ["openai", "watsonx", "ollama", "openai-compatible"]
+
 WATSONX_EMBEDDING_DIMENSIONS = {
 # IBM Models
 "ibm/granite-embedding-107m-multilingual": 384,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+@pytest.fixture(scope="session", autouse=True)
+def onboard_system():
+    """Override the global onboard_system fixture to do nothing for unit tests.
+    
+    This prevents the unit tests from trying to connect to OpenSearch or start the full app.
+    """
+    yield

--- a/tests/unit/test_models_service_custom.py
+++ b/tests/unit/test_models_service_custom.py
@@ -1,0 +1,78 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from src.services.models_service import ModelsService
+
+@pytest.mark.asyncio
+async def test_get_openai_models_with_custom_base_url():
+    """Test fetching models from a custom OpenAI-compatible endpoint."""
+    service = ModelsService()
+    api_key = "test-key"
+    effective_endpoint = "https://custom-provider.com/v1"
+    
+    # Response needs to support .json() (sync) but be returned effectively by async get
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [
+            {"id": "custom-model-1"},
+            {"id": "gpt-4o"},
+            {"id": "text-embedding-3-small"}
+        ]
+    }
+    
+    # Create a MagicMock for the client instance
+    # We use MagicMock because we don't want the instance itself to be awaitable/async,
+    # allows us to define specific async methods (__aenter__, get)
+    mock_client_instance = MagicMock()
+    mock_client_instance.__aenter__.return_value = mock_client_instance
+    mock_client_instance.__aexit__.return_value = None
+    mock_client_instance.get = AsyncMock(return_value=mock_response)
+
+    with patch("httpx.AsyncClient", return_value=mock_client_instance):
+        result = await service.get_openai_models(api_key=api_key, endpoint=effective_endpoint)
+
+        # Check call arguments
+        mock_client_instance.get.assert_called_once()
+        args, kwargs = mock_client_instance.get.call_args
+        assert args[0] == f"{effective_endpoint}/models"
+        
+        # Verify filtering behavior
+        model_ids = [m["value"] for m in result["language_models"]]
+        assert "gpt-4o" in model_ids
+        assert "custom-model-1" not in model_ids
+
+@pytest.mark.asyncio
+async def test_get_openai_compatible_models_no_filtering():
+    """Test that openai-compatible provider does not filter models."""
+    service = ModelsService()
+    api_key = "test-key"
+    
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "data": [
+            {"id": "deepseek-chat"},
+            {"id": "mistral-large"},
+            {"id": "gpt-4o"},
+            {"id": "custom-embedding-model"}
+        ]
+    }
+    
+    # Create a MagicMock for the client instance
+    mock_client_instance = MagicMock()
+    mock_client_instance.__aenter__.return_value = mock_client_instance
+    mock_client_instance.__aexit__.return_value = None
+    mock_client_instance.get = AsyncMock(return_value=mock_response)
+    
+    with patch("httpx.AsyncClient", return_value=mock_client_instance):
+        result = await service.get_openai_models(api_key=api_key, provider="openai-compatible")
+        
+        # All models should be present in language_models
+        model_ids = [m["value"] for m in result["language_models"]]
+        assert "deepseek-chat" in model_ids
+        assert "mistral-large" in model_ids
+        assert "gpt-4o" in model_ids
+        
+        # Check embedding models too
+        embedding_ids = [m["value"] for m in result["embedding_models"]]
+        assert "custom-embedding-model" in embedding_ids


### PR DESCRIPTION
## Description
This PR addresses the limitation where OpenRAG was restricted to a fixed list of LLM/Embedding providers and specific OpenAI API endpoints. 

It introduces:
- **Custom Endpoint Support**: Users can now override the base URL for the `openai` provider (e.g., for local vLLM instances).
- **OpenAI-Compatible Provider**: A new generic provider type that bypasses strict model filtering and allows using any model ID available at the configured endpoint (perfect for OpenRouter, Groq, etc.).
- **Consistent Configuration**: Uniform naming convention for endpoints (`_endpoint` suffix) and automated telemetry event tracking for provider updates.

## Key Changes
- `src/config/config_manager.py`: Added `endpoint` to `OpenAIConfig` and implemented `OpenAICompatibleConfig`.
- `src/api/settings.py`: Exposed new configuration fields and updated onboarding logic.
- `src/services/models_service.py`: Implemented logic to fetch models from custom endpoints without strict filtering.
- `src/services/flows_service.py`: Fixed base URL persistence and added support for the new provider type.
- `src/api/provider_validation.py`: Added health checks and validation for custom providers/endpoints.

## Verification
- Unit tests added in `tests/unit/test_models_service_custom.py` to verify custom endpoint and provider behavior.
- Verified that all existing providers continue to function as expected.
- Tested against local vLLM and OpenRouter endpoints.

Fixes #981.