### PR TITLE
fix: DeleteConfirmationDialog content for large url scan 

### DIFF
--- a/frontend/components/delete-confirmation-dialog.tsx
+++ b/frontend/components/delete-confirmation-dialog.tsx
@@ -78,7 +78,7 @@ export const DeleteConfirmationDialog: React.FC<
             )}
             <DialogTitle>{title}</DialogTitle>
           </div>
-          <DialogDescription>{description}</DialogDescription>
+          <DialogDescription className="!max-h-80 overflow-y-scroll py-6">{description}</DialogDescription>
         </DialogHeader>
 
         <DialogFooter>


### PR DESCRIPTION
When a user tries to delete URL scan "doc", the DeleteConfirmationDialog interpolates the full filename into the description text. Without any height constraint or overflow handling on DialogDescription, this caused the dialog to extend beyond the screen.
Steps to Reproduce
Ingest a URL via the chat agent (or insert a document into OpenSearch where filename contains large text)
Navigate to /knowledge
Attempt to delete the URL-ingested document via the three-dot menu or bulk delete
Before fix: Dialog overflows the viewport, buttons are unreachable, document cannot be deleted
After fix: Dialog description is scrollable, buttons remain accessible, deletion works
