### PR TITLE
fix(security): Clear-text storage of sensitive information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endef
 .PHONY: help check_tools help_docker help_dev help_test help_local help_utils \
        dev dev-cpu dev-local dev-local-cpu stop clean build logs \
        shell-backend shell-frontend install \
-       test test-integration test-ci test-ci-local test-sdk test-os-jwt lint \
+       test test-unit test-integration test-ci test-ci-local test-sdk test-os-jwt lint \
        backend frontend docling docling-stop install-be install-fe build-be build-fe build-os build-lf logs-be logs-fe logs-lf logs-os \
        shell-be shell-lf shell-os restart status health db-reset clear-os-data flow-upload setup factory-reset \
        dev-branch build-langflow-dev stop-dev clean-dev logs-dev logs-lf-dev shell-lf-dev restart-dev status-dev
@@ -226,6 +226,7 @@ help_test: ## Show testing commands
 	@echo ''
 	@echo "$(PURPLE)Unit & Integration Tests:$(NC)"
 	@echo "  $(PURPLE)make test$(NC)            - Run all backend tests"
+	@echo "  $(PURPLE)make test-unit$(NC)       - Run unit tests only (tests/unit/)"
 	@echo "  $(PURPLE)make test-integration$(NC) - Run integration tests (requires infra)"
 	@echo ''
 	@echo "$(PURPLE)CI Tests:$(NC)"
@@ -607,6 +608,11 @@ test: ## Run all backend tests
 	@echo "$(YELLOW)Running all backend tests...$(NC)"
 	uv run pytest tests/ -v
 	@echo "$(PURPLE)Tests complete.$(NC)"
+
+test-unit: ## Run unit tests only
+	@echo "$(YELLOW)Running unit tests...$(NC)"
+	uv run pytest tests/unit/ -v
+	@echo "$(PURPLE)Unit tests complete.$(NC)"
 
 test-integration: ## Run integration tests (requires infrastructure)
 	@echo "$(YELLOW)Running integration tests (requires infrastructure)...$(NC)"

--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -111,6 +111,7 @@ class EnvManager:
                     import shutil
                     self.env_file.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(legacy_env, self.env_file)
+                    os.chmod(self.env_file, 0o600)
                     logger.info(f"Migrated .env from {legacy_env} to {self.env_file}")
 
 
@@ -375,6 +376,7 @@ class EnvManager:
                 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                 backup_file = self.env_file.with_suffix(f".env.backup.{timestamp}")
                 self.env_file.rename(backup_file)
+                os.chmod(backup_file, 0o600)
 
             # Create .env file with secure permissions (owner read/write only) to protect secrets
             fd = os.open(self.env_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)

--- a/tests/unit/test_env_manager.py
+++ b/tests/unit/test_env_manager.py
@@ -1,0 +1,168 @@
+"""Unit tests for EnvManager file permission security.
+
+These tests verify that every code path that writes a .env file enforces
+0o600 (owner read/write only) permissions to prevent cleartext secret
+exposure.  All tests use pytest's built-in ``tmp_path`` fixture and
+``unittest.mock.patch``; no running infrastructure is required.
+"""
+
+import os
+import stat
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Skip all tests on Windows — file permission model differs from Unix.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="Unix file permissions only"
+)
+
+
+def _perms(path: Path) -> int:
+    """Return the permission bits of *path* as an integer (e.g. 0o600)."""
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.fixture
+def env_manager(tmp_path):
+    """EnvManager pointed at a temp directory (no real ~/.openrag I/O)."""
+    from tui.managers.env_manager import EnvManager
+
+    return EnvManager(env_file=tmp_path / ".env")
+
+
+# ---------------------------------------------------------------------------
+# save_env_file
+# ---------------------------------------------------------------------------
+
+
+class TestSaveEnvFilePermissions:
+    """save_env_file must write the .env file with 0o600 permissions."""
+
+    def test_new_file_creation_has_secure_permissions(self, env_manager, tmp_path):
+        """A brand-new .env must be created with 0o600."""
+        env_file = tmp_path / ".env"
+        assert not env_file.exists(), "pre-condition: no .env yet"
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.0.0"):
+            result = env_manager.save_env_file()
+
+        assert result is True
+        assert env_file.exists()
+        assert _perms(env_file) == 0o600, f"expected 0o600, got {oct(_perms(env_file))}"
+
+    def test_overwrite_existing_file_has_secure_permissions(
+        self, env_manager, tmp_path
+    ):
+        """Overwriting a permissive .env (0o644) must produce a new .env with 0o600."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENSEARCH_PASSWORD='old'\n")
+        env_file.chmod(0o644)
+        assert _perms(env_file) == 0o644, "pre-condition: file starts permissive"
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.0.0"):
+            result = env_manager.save_env_file()
+
+        assert result is True
+        assert env_file.exists()
+        assert _perms(env_file) == 0o600, f"expected 0o600, got {oct(_perms(env_file))}"
+
+    def test_backup_file_has_secure_permissions(self, env_manager, tmp_path):
+        """The timestamped backup of a permissive .env (0o644) must be 0o600."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENSEARCH_PASSWORD='old'\n")
+        env_file.chmod(0o644)
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.0.0"):
+            env_manager.save_env_file()
+
+        # After save, the original .env was renamed to the backup; find it.
+        backups = [f for f in tmp_path.iterdir() if f.name != ".env"]
+        assert len(backups) == 1, (
+            f"expected exactly 1 backup file, found: {[f.name for f in backups]}"
+        )
+        assert _perms(backups[0]) == 0o600, (
+            f"expected 0o600, got {oct(_perms(backups[0]))}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ensure_openrag_version
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureOpenragVersionPermissions:
+    """ensure_openrag_version must enforce 0o600 on every .env it touches."""
+
+    def test_existing_file_update_has_secure_permissions(
+        self, env_manager, tmp_path, monkeypatch
+    ):
+        """Updating OPENRAG_VERSION in a permissive .env (0o644) must set 0o600."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("OPENSEARCH_PASSWORD='test'\n")
+        env_file.chmod(0o644)
+        assert _perms(env_file) == 0o644, "pre-condition: file starts permissive"
+
+        # Prevent stale OPENRAG_VERSION in the process environment from
+        # causing ensure_openrag_version to bail out early.
+        monkeypatch.delenv("OPENRAG_VERSION", raising=False)
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.2.3"):
+            env_manager.ensure_openrag_version()
+
+        assert env_file.exists()
+        assert _perms(env_file) == 0o600, f"expected 0o600, got {oct(_perms(env_file))}"
+        assert "OPENRAG_VERSION='1.2.3'" in env_file.read_text()
+
+    def test_new_file_creation_has_secure_permissions(self, env_manager, tmp_path):
+        """When no .env exists ensure_openrag_version must create one with 0o600."""
+        env_file = tmp_path / ".env"
+        assert not env_file.exists(), "pre-condition: no .env yet"
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.2.3"):
+            env_manager.ensure_openrag_version()
+
+        assert env_file.exists()
+        assert _perms(env_file) == 0o600, f"expected 0o600, got {oct(_perms(env_file))}"
+
+
+# ---------------------------------------------------------------------------
+# Legacy migration path (__init__)
+# ---------------------------------------------------------------------------
+
+
+class TestLegacyMigrationPermissions:
+    """EnvManager.__init__ migration path must protect the copied .env with 0o600."""
+
+    def test_migrated_file_has_secure_permissions(self, tmp_path):
+        """A legacy .env (0o644) copied to the new location must get 0o600."""
+        # Create the legacy file with deliberately permissive permissions.
+        legacy_dir = tmp_path / "legacy_dir"
+        legacy_dir.mkdir()
+        legacy_env = legacy_dir / ".env"
+        legacy_env.write_text("OPENSEARCH_PASSWORD='secret'\n")
+        legacy_env.chmod(0o644)
+        assert _perms(legacy_env) == 0o644, "pre-condition: legacy file is permissive"
+
+        # Target path that does not yet exist; its parent will be created by
+        # EnvManager.__init__ via Path.mkdir(parents=True, exist_ok=True).
+        target_env = tmp_path / "new_location" / ".env"
+        assert not target_env.exists(), "pre-condition: target not present"
+
+        with (
+            patch("utils.paths.get_tui_env_file", return_value=target_env),
+            patch(
+                "utils.paths.get_legacy_paths",
+                return_value={"tui_env": legacy_env},
+            ),
+        ):
+            from tui.managers.env_manager import EnvManager
+
+            EnvManager()  # no explicit env_file — triggers the migration branch
+
+        assert target_env.exists(), "migrated file must be present"
+        assert _perms(target_env) == 0o600, (
+            f"expected 0o600, got {oct(_perms(target_env))}"
+        )


### PR DESCRIPTION
### Issues

- #938

### Summary

Hardens .env file handling in EnvManager to prevent cleartext secrets from being exposed via insecure file permissions. All .env file writes now use os.open with 0o600 mode to restrict access to the file owner only, and adds fsync to ensure data durability. Also removes trailing whitespace throughout the file.

### Security Hardening

- Replace `open()` with `os.open(..., 0o600)` + `os.fdopen()` for all .env file writes, ensuring owner-only (read/write) permissions on creation
- Add `os.chmod(self.env_file, 0o600)` when overwriting pre-existing .env files to retroactively restrict permissions
- Add `f.flush()` + `os.fsync()` calls to the main `save_env_file()` write path to guarantee data is durably written to disk
- Apply os.chmod(0o600) to the migrated .env after shutil.copy2 in the
  legacy migration branch (__init__), which previously inherited the
  source file's permissions.
- Apply os.chmod(0o600) to the timestamped backup file created in
  save_env_file before the new .env is written, ensuring the backup is
  also protected.

### Logging Improvements

- Elevate `OPENRAG_VERSION` update error from `logger.debug` to `logger.error` so failures surface in standard log output

### Code Cleanup

- Remove redundant `import os` statement in `ensure_version_in_env()` (already imported at module level)
- Strip trailing whitespace on blank lines throughout the file

### Tests

- Add tests/unit/test_env_manager.py with 168 lines of unit tests covering
  all three affected code paths:
  - TestSaveEnvFilePermissions: new file creation, overwrite of a permissive
    existing file, and backup file permissions.
  - TestEnsureOpenragVersionPermissions: update of an existing permissive
    file and creation of a new file.
  - TestLegacyMigrationPermissions: migrated file receives 0o600 after copy.
- All tests use pytest tmp_path and unittest.mock; no running infrastructure
  required. Tests are skipped on Windows (Unix permission model only).

### Build / Developer Experience

- Add test-unit Makefile target (uv run pytest tests/unit/ -v) for running
  unit tests in isolation without triggering integration tests.
- Register test-unit in .PHONY and add it to the help_test output.

---

### Full Background Info on Remediation

- https://github.com/langflow-ai/openrag/issues/938#issuecomment-3935331120

---

### Related PRs

- https://github.com/langflow-ai/openrag/pull/937

---

### Test Coverage

Test 1 — save_env_file: new file creation                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                       
- No .env exists.                                                                                                                                                                                                                                                                      
- Call save_env_file().                                                                                                                                                                                                                                                               
- Assert file exists and stat.S_IMODE == 0o600.                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                       
Test 2 — save_env_file: new .env when prior file exists (permissions)                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                       
- Create a pre-existing .env with 0o644 permissions.                                                                                                                                                                                                                                   
- Call save_env_file().                                                                                                                                                                                                                                                                
- Assert the new .env has 0o600.                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                       
Test 3 — save_env_file: backup file permissions                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                       
- Create a pre-existing .env with 0o644 permissions.                                                                                                                                                                                                                                   
- Call save_env_file().                                                                                                                                                                                                                                                                
- Glob for .env.backup.* in tmp_path.                                                                                                                                                                                                                                                  
- Assert exactly one backup exists and its permissions are 0o600.                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                       
Test 4 — ensure_openrag_version: existing file update path                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                       
- Create an .env file with 0o644 permissions containing no OPENRAG_VERSION line.                                                                                                                                                                                                       
- Mock get_current_version() to return "1.2.3".                                                                                                                                                                                                                                        
- Call env_manager.ensure_openrag_version().                                                                                                                                                                                                                                           
- Assert file permissions are 0o600 and file contains OPENRAG_VERSION='1.2.3'.                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                       
Test 5 — ensure_openrag_version: new file creation path                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                       
- No .env exists.                                                                                                                                                                                                                                                                      
- Mock get_current_version() to return "1.2.3".                                                                                                                                                                                                                                        
- Call env_manager.ensure_openrag_version().                                                                                                                                                                                                                                           
- Assert file is created with 0o600 permissions.                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                       
Test 6 — Legacy migration path in __init__                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                       
- Create a legacy_env file in tmp_path with 0o644 permissions and some content.                                                                                                                                                                                                        
- Mock get_tui_env_file() to return a path that does not exist.                                                                                                                                                                                                                        
- Mock get_legacy_paths() to return {"tui_env": legacy_env}.                                                                                                                                                                                                                           
- Instantiate EnvManager() (no explicit env_file).                                                                                                                                                                                                                                    
- Assert the migrated file exists and has 0o600 permissions.   

6 tests across 3 classes:

```
┌───────────────────────────────────────────────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────┐
│                                         Test                                          │                              Verifies                              │
├───────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ TestSaveEnvFilePermissions::test_new_file_creation_has_secure_permissions             │ New .env created via save_env_file gets 0o600                      │
├───────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ TestSaveEnvFilePermissions::test_overwrite_existing_file_has_secure_permissions       │ New .env written over a permissive 0o644 file gets 0o600           │
├───────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ TestSaveEnvFilePermissions::test_backup_file_has_secure_permissions                   │ Timestamped backup of a permissive 0o644 file gets 0o600           │
├───────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ TestEnsureOpenragVersionPermissions::test_existing_file_update_has_secure_permissions │ Updating OPENRAG_VERSION in a permissive 0o644 file enforces 0o600 │
├───────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ TestEnsureOpenragVersionPermissions::test_new_file_creation_has_secure_permissions    │ New .env created by ensure_openrag_version gets 0o600              │
├───────────────────────────────────────────────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────┤
│ TestLegacyMigrationPermissions::test_migrated_file_has_secure_permissions             │ Legacy 0o644 .env copied via __init__ migration path gets 0o600    │
└───────────────────────────────────────────────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────┘
 ```
 

