### PR TITLE
spike:Section wise integation test refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -619,6 +619,22 @@ test-integration: ## Run integration tests (requires infrastructure)
 	@echo "$(CYAN)Make sure to run 'make dev-local' first!$(NC)"
 	uv run pytest tests/integration/ -v
 
+test-integration-upload: ## Run only upload/ingest integration tests
+	@echo "$(YELLOW)Running upload integration tests...$(NC)"
+	uv run pytest tests/integration/ -m section_upload -vv -s
+
+test-integration-search: ## Run only search integration tests
+	@echo "$(YELLOW)Running search integration tests...$(NC)"
+	uv run pytest tests/integration/ -m section_search -vv -s
+
+test-integration-startup: ## Run only startup ingest integration tests
+	@echo "$(YELLOW)Running startup integration tests...$(NC)"
+	uv run pytest tests/integration/ -m section_startup -vv -s
+
+test-integration-langflow: ## Run only Langflow integration tests
+	@echo "$(YELLOW)Running Langflow integration tests...$(NC)"
+	uv run pytest tests/integration/ -m section_langflow -vv -s
+
 test-ci: ## Start infra, run integration + SDK tests, tear down (uses DockerHub images)
 	@set -e; \
 	echo "$(YELLOW)Installing test dependencies...$(NC)"; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,17 @@ dev = ["pytest>=8", "pytest-asyncio>=0.21.0", "pytest-mock>=3.12.0", "pytest-cov
 [project.scripts]
 openrag = "tui.main:run_tui"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "session"
+testpaths = ["tests"]
+markers = [
+    "section_upload: Upload and ingestion endpoint tests",
+    "section_search: Search endpoint tests",
+    "section_startup: Startup ingestion tests",
+    "section_langflow: Langflow-dependent tests",
+]
+
 [tool.uv]
 package = true
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-import asyncio
 import os
 import tempfile
 from pathlib import Path
@@ -67,7 +66,7 @@ async def onboard_system():
             # If it fails, it might already be onboarded, which is fine
             print(f"[DEBUG] Onboarding returned {resp.status_code}: {resp.text}")
         else:
-            print(f"[DEBUG] Session onboarding completed successfully")
+            print("[DEBUG] Session onboarding completed successfully")
 
     yield
 
@@ -76,14 +75,6 @@ async def onboard_system():
         await clients.close()
     except Exception:
         pass
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    """Create an instance of the default event loop for the test session."""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest_asyncio.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,146 @@
+"""Integration test fixtures.
+
+Centralises the module-reload / app-creation / index-cleanup boilerplate that
+was previously copy-pasted into every integration test function.
+"""
+
+import asyncio
+import os
+import sys
+import httpx
+import pytest_asyncio
+
+# Canonical superset of modules that must be evicted from ``sys.modules``
+# before re-importing so that changed environment variables are picked up.
+MODULES_TO_RELOAD = [
+    "api.router",
+    "api.connector_router",
+    "api.chat",
+    "api.nudges",
+    "config.settings",
+    "auth_middleware",
+    "main",
+    "api",
+    "services",
+    "services.search_service",
+    "services.chat_service",
+]
+
+
+def reload_settings(env_overrides: dict[str, str] | None = None):
+    """Apply *env_overrides*, evict cached modules, and re-import key symbols.
+
+    Returns a dict with the freshly-imported objects that tests typically need:
+    ``create_app``, ``startup_tasks``, ``_ensure_opensearch_index``,
+    ``clients``, ``get_index_name``.
+    """
+    defaults = {
+        "DISABLE_STARTUP_INGEST": "true",
+        "EMBEDDING_MODEL": "text-embedding-3-small",
+        "EMBEDDING_PROVIDER": "openai",
+        "GOOGLE_OAUTH_CLIENT_ID": "",
+        "GOOGLE_OAUTH_CLIENT_SECRET": "",
+    }
+    for key, val in defaults.items():
+        os.environ.setdefault(key, val)
+    if env_overrides:
+        os.environ.update(env_overrides)
+
+    for mod in MODULES_TO_RELOAD:
+        sys.modules.pop(mod, None)
+
+    from main import create_app, startup_tasks, _ensure_opensearch_index
+    from config.settings import clients, get_index_name
+
+    return {
+        "create_app": create_app,
+        "startup_tasks": startup_tasks,
+        "_ensure_opensearch_index": _ensure_opensearch_index,
+        "clients": clients,
+        "get_index_name": get_index_name,
+    }
+
+
+@pytest_asyncio.fixture
+async def fresh_app(request):
+    """Function-scoped fixture that creates a clean ASGI app.
+
+    Accepts ``disable_langflow_ingest`` via parametrize; falls back to ``True``.
+
+    Yields ``(app, clients, get_index_name)`` and tears down clients on exit.
+    """
+    disable_langflow = getattr(request, "param", None)
+    if disable_langflow is None:
+        disable_langflow = request.node.callobj.__defaults__
+        if disable_langflow:
+            disable_langflow = disable_langflow[0]
+        else:
+            disable_langflow = True
+
+    # If test is parametrized with ``disable_langflow_ingest``, grab from there
+    if "disable_langflow_ingest" in (request.fixturenames or []):
+        disable_langflow = request.getfixturevalue("disable_langflow_ingest")
+
+    env = {
+        "DISABLE_INGEST_WITH_LANGFLOW": "true" if disable_langflow else "false",
+    }
+
+    ctx = reload_settings(env)
+    clients = ctx["clients"]
+    create_app = ctx["create_app"]
+    startup_tasks = ctx["startup_tasks"]
+    ensure_index = ctx["_ensure_opensearch_index"]
+    get_index_name = ctx["get_index_name"]
+
+    await clients.initialize()
+
+    app = await create_app()
+    await startup_tasks(app.state.services)
+    await ensure_index()
+
+    yield app, clients, get_index_name
+
+    try:
+        await clients.close()
+    except Exception:
+        pass
+
+
+@pytest_asyncio.fixture
+async def clean_index(fresh_app):
+    """Delete and recreate the OpenSearch index so the test starts empty."""
+    app, clients, get_index_name = fresh_app
+    index = get_index_name()
+
+    try:
+        await clients.opensearch.indices.delete(index=index)
+        # Wait for the deletion to propagate
+        await asyncio.sleep(1)
+    except Exception:
+        pass
+
+    from main import _ensure_opensearch_index
+    await _ensure_opensearch_index()
+
+    # Confirm the index is empty
+    try:
+        resp = await clients.opensearch.count(index=index)
+        count = resp.get("count", 0)
+        if count > 0:
+            print(f"[WARN] Index {index} still has {count} docs after cleanup")
+    except Exception:
+        pass
+
+    yield app, clients, get_index_name
+
+
+@pytest_asyncio.fixture
+async def test_http_client(fresh_app):
+    """Provide an ``httpx.AsyncClient`` wired to the ASGI app.
+
+    Waits for the service to be ready before yielding.
+    """
+    app, _clients, _get_index_name = fresh_app
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -6,14 +6,23 @@ from pathlib import Path
 import httpx
 import pytest
 
+from tests.integration.conftest import reload_settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 def dump_docker_logs(container_name_pattern: str = "langflow", tail: int = 100):
     """Dump Docker container logs for debugging."""
     try:
-        # Find container ID by name pattern
-        find_cmd = ["docker", "ps", "-a", "--filter", f"name={container_name_pattern}", "--format", "{{.ID}}"]
+        find_cmd = [
+            "docker", "ps", "-a",
+            "--filter", f"name={container_name_pattern}",
+            "--format", "{{.ID}}",
+        ]
         result = subprocess.run(find_cmd, capture_output=True, text=True, timeout=5)
-        container_ids = result.stdout.strip().split('\n')
+        container_ids = result.stdout.strip().split("\n")
 
         if not container_ids or not container_ids[0]:
             print(f"[DEBUG] No Docker containers found matching pattern: {container_name_pattern}")
@@ -22,60 +31,63 @@ def dump_docker_logs(container_name_pattern: str = "langflow", tail: int = 100):
         for container_id in container_ids:
             if not container_id:
                 continue
-            print(f"\n{'='*80}")
+            print(f"\n{'=' * 80}")
             print(f"[DEBUG] Docker logs for container {container_id} (last {tail} lines):")
-            print(f"{'='*80}")
+            print(f"{'=' * 80}")
 
             logs_cmd = ["docker", "logs", "--tail", str(tail), container_id]
             logs_result = subprocess.run(logs_cmd, capture_output=True, text=True, timeout=10)
             print(logs_result.stdout)
             if logs_result.stderr:
                 print("[STDERR]:", logs_result.stderr)
-            print(f"{'='*80}\n")
+            print(f"{'=' * 80}\n")
     except subprocess.TimeoutExpired:
         print(f"[DEBUG] Timeout while fetching docker logs for {container_name_pattern}")
     except Exception as e:
         print(f"[DEBUG] Failed to fetch docker logs for {container_name_pattern}: {e}")
 
 
-async def wait_for_service_ready(client: httpx.AsyncClient, timeout_s: float = 30.0):
+async def wait_for_service_ready(client: httpx.AsyncClient, timeout_s: float = 60.0):
     """Poll existing endpoints until the app and OpenSearch are ready.
 
     Strategy:
     - GET /auth/me should return 200 immediately (confirms app is up).
     - POST /search with query "*" avoids embeddings and checks OpenSearch/index readiness.
     """
-    # First test OpenSearch JWT directly
     from session_manager import SessionManager, AnonymousUser
-    import os
     import hashlib
     import jwt as jwt_lib
+
     sm = SessionManager("test")
     test_token = sm.create_jwt_token(AnonymousUser())
     token_hash = hashlib.sha256(test_token.encode()).hexdigest()[:16]
     print(f"[DEBUG] Generated test JWT token hash: {token_hash}")
     print(f"[DEBUG] Using key paths: private={sm.private_key_path}, public={sm.public_key_path}")
-    with open(sm.public_key_path, 'rb') as f:
+    with open(sm.public_key_path, "rb") as f:
         pub_key_hash = hashlib.sha256(f.read()).hexdigest()[:16]
     print(f"[DEBUG] Public key hash: {pub_key_hash}")
-    # Decode token to see claims
     decoded = jwt_lib.decode(test_token, options={"verify_signature": False})
-    print(f"[DEBUG] JWT claims: iss={decoded.get('iss')}, sub={decoded.get('sub')}, aud={decoded.get('aud')}, roles={decoded.get('roles')}")
+    print(
+        f"[DEBUG] JWT claims: iss={decoded.get('iss')}, sub={decoded.get('sub')}, "
+        f"aud={decoded.get('aud')}, roles={decoded.get('roles')}"
+    )
 
-    # Test OpenSearch JWT auth directly
-    opensearch_url = f"https://{os.getenv('OPENSEARCH_HOST', 'localhost')}:{os.getenv('OPENSEARCH_PORT', '9200')}"
+    opensearch_url = (
+        f"https://{os.getenv('OPENSEARCH_HOST', 'localhost')}:"
+        f"{os.getenv('OPENSEARCH_PORT', '9200')}"
+    )
     print(f"[DEBUG] Testing JWT auth directly against: {opensearch_url}/documents/_search")
     async with httpx.AsyncClient(verify=False) as os_client:
         r_os = await os_client.post(
             f"{opensearch_url}/documents/_search",
             headers={"Authorization": f"Bearer {test_token}"},
-            json={"query": {"match_all": {}}, "size": 0}
+            json={"query": {"match_all": {}}, "size": 0},
         )
         print(f"[DEBUG] Direct OpenSearch JWT test: status={r_os.status_code}, body={r_os.text[:500]}")
         if r_os.status_code == 401:
-            print(f"[DEBUG] ❌ OpenSearch rejected JWT! OIDC config not working.")
+            print("[DEBUG] OpenSearch rejected JWT! OIDC config not working.")
         else:
-            print(f"[DEBUG] ✓ OpenSearch accepted JWT!")
+            print("[DEBUG] OpenSearch accepted JWT!")
 
     deadline = asyncio.get_event_loop().time() + timeout_s
     last_err = None
@@ -88,7 +100,6 @@ async def wait_for_service_ready(client: httpx.AsyncClient, timeout_s: float = 3
             if r1.status_code != 200:
                 await asyncio.sleep(0.5)
                 continue
-            # match_all readiness probe; no embeddings
             r2 = await client.post("/search", json={"query": "*", "limit": 0})
             print(f"[DEBUG] /search status={r2.status_code}, body={r2.text[:200]}")
             if r2.status_code in (401, 403):
@@ -105,196 +116,6 @@ async def wait_for_service_ready(client: httpx.AsyncClient, timeout_s: float = 3
             print(f"[DEBUG] Exception during readiness check: {e}")
         await asyncio.sleep(0.5)
     raise AssertionError(f"Service not ready in time: {last_err}")
-
-
-@pytest.mark.parametrize("disable_langflow_ingest", [True, False])
-@pytest.mark.asyncio
-async def test_upload_and_search_endpoint(tmp_path: Path, disable_langflow_ingest: bool):
-    """Boot the ASGI app and exercise /upload and /search endpoints."""
-    # Ensure we route uploads to traditional processor and disable startup ingest
-    os.environ["DISABLE_INGEST_WITH_LANGFLOW"] = "true" if disable_langflow_ingest else "false"
-    os.environ["DISABLE_STARTUP_INGEST"] = "true"
-    os.environ["EMBEDDING_MODEL"] = "text-embedding-3-small"
-    os.environ["EMBEDDING_PROVIDER"] = "openai"
-    # Force no-auth mode so endpoints bypass authentication
-    os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
-    os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
-
-    # Import after env vars to ensure settings pick them up. Clear cached modules
-    import sys
-    # Clear cached modules so settings pick up env and router sees new flag
-    for mod in [
-        "api.router",
-        "api.connector_router",
-        "config.settings",
-        "auth_middleware",
-        "main",
-        "api",
-        "services",
-        "services.search_service",
-    ]:
-        sys.modules.pop(mod, None)
-    from main import create_app, startup_tasks
-    import api.router as upload_router
-    from config.settings import clients, get_index_name, DISABLE_INGEST_WITH_LANGFLOW
-
-    # Ensure a clean index before startup
-    await clients.initialize()
-    try:
-        await clients.opensearch.indices.delete(index=get_index_name())
-        # Wait for deletion to complete
-        await asyncio.sleep(1)
-    except Exception:
-        pass
-
-    app = await create_app()
-    # Manually run startup tasks since httpx ASGI transport here doesn't manage lifespan
-    await startup_tasks(app.state.services)
-
-    # Ensure index exists for tests (startup_tasks only creates it if DISABLE_INGEST_WITH_LANGFLOW=True)
-    from main import _ensure_opensearch_index
-    await _ensure_opensearch_index()
-
-    # Verify index is truly empty after startup
-    try:
-        count_response = await clients.opensearch.count(index=get_index_name())
-        doc_count = count_response.get('count', 0)
-        assert doc_count == 0, f"Index should be empty after startup but contains {doc_count} documents"
-    except Exception as e:
-        # If count fails, the index might not exist yet, which is fine
-        pass
-
-    transport = httpx.ASGITransport(app=app)
-    try:
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            # Wait for app + OpenSearch readiness using existing endpoints
-            await wait_for_service_ready(client)
-
-            # Create a temporary markdown file to upload
-            file_path = tmp_path / "endpoint_test_doc.md"
-            file_text = (
-                "# Single Test Document\n\n"
-                "This is a test document about OpenRAG testing framework. "
-                "The content should be indexed and searchable in OpenSearch after processing."
-            )
-            file_path.write_text(file_text)
-
-            # POST via router (multipart)
-            files = {
-                "file": (
-                    file_path.name,
-                    file_path.read_bytes(),
-                    "text/markdown",
-                )
-            }
-            upload_resp = await client.post("/router/upload_ingest", files=files)
-            body = upload_resp.json()
-            assert upload_resp.status_code in (201, 202), upload_resp.text
-
-            # Handle different response formats based on whether Langflow is used
-            if disable_langflow_ingest:
-                # Traditional OpenRAG response (201)
-                assert body.get("status") in {"indexed", "unchanged"}
-                assert isinstance(body.get("id"), str)
-            else:
-                # Langflow task response (202)
-                task_id = body.get("task_id")
-                assert isinstance(task_id, str)
-                assert body.get("file_count") == 1
-                # Wait for task completion before searching
-                await _wait_for_task_completion(client, task_id)
-
-            # Poll search for the specific content until it's indexed
-            async def _wait_for_indexed(timeout_s: float = 30.0):
-                deadline = asyncio.get_event_loop().time() + timeout_s
-                while asyncio.get_event_loop().time() < deadline:
-                    resp = await client.post(
-                        "/search",
-                        json={"query": "OpenRAG testing framework", "limit": 5},
-                    )
-                    if resp.status_code == 200 and resp.json().get("results"):
-                        return resp
-                    await asyncio.sleep(0.5)
-                return resp
-
-            search_resp = await _wait_for_indexed()
-
-            # POST /search
-            assert search_resp.status_code == 200, search_resp.text
-            search_body = search_resp.json()
-
-            # Basic shape and at least one hit
-            assert isinstance(search_body.get("results"), list)
-            assert len(search_body["results"]) >= 0
-            # When hits exist, confirm our phrase is present in top result content
-            if search_body["results"]:
-                top = search_body["results"][0]
-                assert "text" in top or "content" in top
-                text = top.get("text") or top.get("content")
-                assert isinstance(text, str)
-                assert "testing" in text.lower()
-    finally:
-        # Explicitly close global clients to avoid aiohttp warnings
-        from config.settings import clients
-        try:
-            await clients.close()
-        except Exception:
-            pass
-
-
-async def _wait_for_langflow_chat(
-    client: httpx.AsyncClient, payload: dict, timeout_s: float = 120.0
-) -> dict:
-    deadline = asyncio.get_event_loop().time() + timeout_s
-    last_payload = None
-    while asyncio.get_event_loop().time() < deadline:
-        resp = await client.post("/langflow", json=payload)
-        if resp.status_code == 200:
-            try:
-                data = resp.json()
-            except Exception:
-                last_payload = resp.text
-            else:
-                response_text = data.get("response")
-                if isinstance(response_text, str) and response_text.strip():
-                    return data
-                last_payload = data
-        else:
-            last_payload = resp.text
-        await asyncio.sleep(1.0)
-
-    # Dump Langflow logs before raising error
-    print(f"\n[DEBUG] /langflow timed out. Dumping Langflow container logs...")
-    dump_docker_logs(container_name_pattern="langflow", tail=200)
-    raise AssertionError(f"/langflow never returned a usable response. Last payload: {last_payload}")
-
-
-async def _wait_for_nudges(
-    client: httpx.AsyncClient, chat_id: str | None = None, timeout_s: float = 90.0
-) -> dict:
-    endpoint = "/nudges" if not chat_id else f"/nudges/{chat_id}"
-    deadline = asyncio.get_event_loop().time() + timeout_s
-    last_payload = None
-    while asyncio.get_event_loop().time() < deadline:
-        resp = await client.get(endpoint)
-        if resp.status_code == 200:
-            try:
-                data = resp.json()
-            except Exception:
-                last_payload = resp.text
-            else:
-                response_text = data.get("response")
-                if isinstance(response_text, str) and response_text.strip():
-                    return data
-                last_payload = data
-        else:
-            last_payload = resp.text
-        await asyncio.sleep(1.0)
-
-    # Dump Langflow logs before raising error
-    print(f"\n[DEBUG] {endpoint} timed out. Dumping Langflow container logs...")
-    dump_docker_logs(container_name_pattern="langflow", tail=200)
-    raise AssertionError(f"{endpoint} never returned a usable response. Last payload: {last_payload}")
 
 
 async def _wait_for_task_completion(
@@ -326,38 +147,255 @@ async def _wait_for_task_completion(
     )
 
 
-@pytest.mark.asyncio
-@pytest.mark.skip
+async def _wait_for_langflow_chat(
+    client: httpx.AsyncClient, payload: dict, timeout_s: float = 120.0
+) -> dict:
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    last_payload = None
+    while asyncio.get_event_loop().time() < deadline:
+        resp = await client.post("/langflow", json=payload)
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+            except Exception:
+                last_payload = resp.text
+            else:
+                response_text = data.get("response")
+                if isinstance(response_text, str) and response_text.strip():
+                    return data
+                last_payload = data
+        else:
+            last_payload = resp.text
+        await asyncio.sleep(1.0)
+
+    print("\n[DEBUG] /langflow timed out. Dumping Langflow container logs...")
+    dump_docker_logs(container_name_pattern="langflow", tail=200)
+    raise AssertionError(f"/langflow never returned a usable response. Last payload: {last_payload}")
+
+
+async def _wait_for_nudges(
+    client: httpx.AsyncClient, chat_id: str | None = None, timeout_s: float = 90.0
+) -> dict:
+    endpoint = "/nudges" if not chat_id else f"/nudges/{chat_id}"
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    last_payload = None
+    while asyncio.get_event_loop().time() < deadline:
+        resp = await client.get(endpoint)
+        if resp.status_code == 200:
+            try:
+                data = resp.json()
+            except Exception:
+                last_payload = resp.text
+            else:
+                response_text = data.get("response")
+                if isinstance(response_text, str) and response_text.strip():
+                    return data
+                last_payload = data
+        else:
+            last_payload = resp.text
+        await asyncio.sleep(1.0)
+
+    print(f"\n[DEBUG] {endpoint} timed out. Dumping Langflow container logs...")
+    dump_docker_logs(container_name_pattern="langflow", tail=200)
+    raise AssertionError(f"{endpoint} never returned a usable response. Last payload: {last_payload}")
+
+
+# ---------------------------------------------------------------------------
+# SECTION: Upload
+# ---------------------------------------------------------------------------
+
+@pytest.mark.section_upload
+@pytest.mark.section_search
+@pytest.mark.parametrize("disable_langflow_ingest", [True, False])
+async def test_upload_and_search_endpoint(tmp_path: Path, disable_langflow_ingest: bool):
+    """Boot the ASGI app and exercise /upload and /search endpoints."""
+    ctx = reload_settings({
+        "DISABLE_INGEST_WITH_LANGFLOW": "true" if disable_langflow_ingest else "false",
+    })
+    clients = ctx["clients"]
+    create_app = ctx["create_app"]
+    startup_tasks = ctx["startup_tasks"]
+    ensure_index = ctx["_ensure_opensearch_index"]
+    get_index_name = ctx["get_index_name"]
+
+    await clients.initialize()
+    try:
+        await clients.opensearch.indices.delete(index=get_index_name())
+        await asyncio.sleep(1)
+    except Exception:
+        pass
+
+    app = await create_app()
+    await startup_tasks(app.state.services)
+    await ensure_index()
+
+    # Verify index is truly empty after startup
+    try:
+        count_response = await clients.opensearch.count(index=get_index_name())
+        doc_count = count_response.get("count", 0)
+        assert doc_count == 0, f"Index should be empty after startup but contains {doc_count} documents"
+    except Exception:
+        pass
+
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            await wait_for_service_ready(client)
+
+            file_path = tmp_path / "endpoint_test_doc.md"
+            file_text = (
+                "# Single Test Document\n\n"
+                "This is a test document about OpenRAG testing framework. "
+                "The content should be indexed and searchable in OpenSearch after processing."
+            )
+            file_path.write_text(file_text)
+
+            files = {
+                "file": (
+                    file_path.name,
+                    file_path.read_bytes(),
+                    "text/markdown",
+                )
+            }
+            upload_resp = await client.post("/router/upload_ingest", files=files)
+            body = upload_resp.json()
+            assert upload_resp.status_code in (201, 202), upload_resp.text
+
+            if disable_langflow_ingest:
+                assert body.get("status") in {"indexed", "unchanged"}
+                assert isinstance(body.get("id"), str)
+            else:
+                task_id = body.get("task_id")
+                assert isinstance(task_id, str)
+                assert body.get("file_count") == 1
+                await _wait_for_task_completion(client, task_id)
+
+            # Force an index refresh so the document is immediately searchable
+            try:
+                await clients.opensearch.indices.refresh(index=get_index_name())
+            except Exception:
+                pass
+
+            async def _wait_for_indexed(timeout_s: float = 60.0):
+                deadline = asyncio.get_event_loop().time() + timeout_s
+                while asyncio.get_event_loop().time() < deadline:
+                    resp = await client.post(
+                        "/search",
+                        json={"query": "OpenRAG testing framework", "limit": 5},
+                    )
+                    if resp.status_code == 200 and resp.json().get("results"):
+                        return resp
+                    await asyncio.sleep(0.5)
+                return resp
+
+            search_resp = await _wait_for_indexed()
+
+            assert search_resp.status_code == 200, search_resp.text
+            search_body = search_resp.json()
+
+            assert isinstance(search_body.get("results"), list)
+            assert len(search_body["results"]) >= 0
+            if search_body["results"]:
+                top = search_body["results"][0]
+                assert "text" in top or "content" in top
+                text = top.get("text") or top.get("content")
+                assert isinstance(text, str)
+                assert "testing" in text.lower()
+    finally:
+        from config.settings import clients as _clients
+        try:
+            await _clients.close()
+        except Exception:
+            pass
+
+
+@pytest.mark.section_upload
+@pytest.mark.parametrize("disable_langflow_ingest", [True, False])
+async def test_router_upload_ingest_traditional(tmp_path: Path, disable_langflow_ingest: bool):
+    """Exercise the router endpoint to ensure it routes to traditional upload when Langflow ingest is disabled."""
+    ctx = reload_settings({
+        "DISABLE_INGEST_WITH_LANGFLOW": "true" if disable_langflow_ingest else "false",
+    })
+    clients = ctx["clients"]
+    create_app = ctx["create_app"]
+    startup_tasks = ctx["startup_tasks"]
+    ensure_index = ctx["_ensure_opensearch_index"]
+    get_index_name = ctx["get_index_name"]
+
+    await clients.initialize()
+    try:
+        await clients.opensearch.indices.delete(index=get_index_name())
+        await asyncio.sleep(1)
+    except Exception:
+        pass
+
+    app = await create_app()
+    await startup_tasks(app.state.services)
+    await ensure_index()
+
+    try:
+        count_response = await clients.opensearch.count(index=get_index_name())
+        doc_count = count_response.get("count", 0)
+        assert doc_count == 0, f"Index should be empty after startup but contains {doc_count} documents"
+    except Exception:
+        pass
+
+    transport = httpx.ASGITransport(app=app)
+    try:
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            await wait_for_service_ready(client)
+
+            file_path = tmp_path / "router_test_doc.md"
+            file_path.write_text("# Router Test\n\nThis file validates the upload router.")
+
+            files = {
+                "file": (
+                    file_path.name,
+                    file_path.read_bytes(),
+                    "text/markdown",
+                )
+            }
+
+            resp = await client.post("/router/upload_ingest", files=files)
+            data = resp.json()
+
+            print(f"data: {data}")
+            if disable_langflow_ingest:
+                assert resp.status_code in (201, 202), resp.text
+                assert data.get("status") in {"indexed", "unchanged"}
+                assert isinstance(data.get("id"), str)
+            else:
+                assert resp.status_code in (201, 202), resp.text
+                assert isinstance(data.get("task_id"), str)
+                assert data.get("file_count") == 1
+    finally:
+        from config.settings import clients as _clients
+        try:
+            await _clients.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# SECTION: Langflow
+# ---------------------------------------------------------------------------
+
+@pytest.mark.section_langflow
+@pytest.mark.skip(reason="Requires Langflow flow IDs configured in environment")
 async def test_langflow_chat_and_nudges_endpoints():
     """Exercise /langflow and /nudges endpoints against a live Langflow backend."""
     required_env = ["LANGFLOW_CHAT_FLOW_ID", "NUDGES_FLOW_ID"]
     missing = [var for var in required_env if not os.getenv(var)]
     assert not missing, f"Missing required Langflow configuration: {missing}"
 
-    os.environ["DISABLE_INGEST_WITH_LANGFLOW"] = "true"
-    os.environ["DISABLE_STARTUP_INGEST"] = "true"
-    os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
-    os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
+    ctx = reload_settings({
+        "DISABLE_INGEST_WITH_LANGFLOW": "true",
+    })
+    clients = ctx["clients"]
+    create_app = ctx["create_app"]
+    startup_tasks = ctx["startup_tasks"]
 
-    import sys
-
-    for mod in [
-        "api.chat",
-        "api.nudges",
-        "api.router",
-        "api.connector_router",
-        "config.settings",
-        "auth_middleware",
-        "main",
-        "api",
-        "services",
-        "services.search_service",
-        "services.chat_service",
-    ]:
-        sys.modules.pop(mod, None)
-
-    from main import create_app, startup_tasks
-    from config.settings import clients, LANGFLOW_CHAT_FLOW_ID, NUDGES_FLOW_ID
+    from config.settings import LANGFLOW_CHAT_FLOW_ID, NUDGES_FLOW_ID
 
     assert LANGFLOW_CHAT_FLOW_ID, "LANGFLOW_CHAT_FLOW_ID must be configured for integration test"
     assert NUDGES_FLOW_ID, "NUDGES_FLOW_ID must be configured for integration test"
@@ -373,14 +411,15 @@ async def test_langflow_chat_and_nudges_endpoints():
         if langflow_client is not None:
             break
         await asyncio.sleep(1.0)
-    assert langflow_client is not None, "Langflow client not initialized. Provide LANGFLOW_KEY or enable superuser auto-login."
+    assert langflow_client is not None, (
+        "Langflow client not initialized. Provide LANGFLOW_KEY or enable superuser auto-login."
+    )
 
     transport = httpx.ASGITransport(app=app)
     try:
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
             await wait_for_service_ready(client)
 
-            # Ensure embedding model is configured via settings
             resp = await client.post(
                 "/settings",
                 json={
@@ -426,39 +465,29 @@ async def test_langflow_chat_and_nudges_endpoints():
                 assert isinstance(nudges_thread_data.get("response"), str)
                 assert nudges_thread_data["response"].strip()
     finally:
-        from config.settings import clients
-
+        from config.settings import clients as _clients
         try:
-            await clients.close()
+            await _clients.close()
         except Exception:
             pass
 
 
-@pytest.mark.skip
-@pytest.mark.asyncio
-async def test_search_multi_embedding_models(
-    tmp_path: Path
-):
+# ---------------------------------------------------------------------------
+# SECTION: Search (multi-model)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.section_search
+@pytest.mark.skip(reason="Requires multiple embedding model configurations")
+async def test_search_multi_embedding_models(tmp_path: Path):
     """Ensure /search fans out across multiple embedding models when present."""
-    os.environ["DISABLE_INGEST_WITH_LANGFLOW"] = "true"
-    os.environ["DISABLE_STARTUP_INGEST"] = "true"
-    os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
-    os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
-
-    import sys
-
-    for mod in [
-        "api.router",
-        "api.connector_router",
-        "config.settings",
-        "auth_middleware",
-        "main",
-        "services.search_service",
-    ]:
-        sys.modules.pop(mod, None)
-
-    from main import create_app, startup_tasks
-    from config.settings import clients, get_index_name
+    ctx = reload_settings({
+        "DISABLE_INGEST_WITH_LANGFLOW": "true",
+    })
+    clients = ctx["clients"]
+    create_app = ctx["create_app"]
+    startup_tasks = ctx["startup_tasks"]
+    ensure_index = ctx["_ensure_opensearch_index"]
+    get_index_name = ctx["get_index_name"]
 
     await clients.initialize()
     try:
@@ -469,10 +498,7 @@ async def test_search_multi_embedding_models(
 
     app = await create_app()
     await startup_tasks(app.state.services)
-
-    from main import _ensure_opensearch_index
-
-    await _ensure_opensearch_index()
+    await ensure_index()
 
     transport = httpx.ASGITransport(app=app)
 
@@ -524,7 +550,6 @@ async def test_search_multi_embedding_models(
                     f"Embedding models not detected. Last payload: {last_payload}"
                 )
 
-            # Start with explicit small embedding model
             resp = await client.post(
                 "/settings",
                 json={
@@ -534,7 +559,6 @@ async def test_search_multi_embedding_models(
             )
             assert resp.status_code == 200, resp.text
 
-            # Ingest first document (small model)
             await _upload_doc("doc-small.md", "Physics basics and fundamental principles.")
             payload_small = await _wait_for_models({"text-embedding-3-small"})
             result_models_small = {
@@ -544,14 +568,12 @@ async def test_search_multi_embedding_models(
             }
             assert "text-embedding-3-small" in result_models_small or not result_models_small
 
-            # Update embedding model via settings
             resp = await client.post(
                 "/settings",
                 json={"embedding_model": "text-embedding-3-large"},
             )
             assert resp.status_code == 200, resp.text
 
-            # Ingest second document which should use the large embedding model
             await _upload_doc("doc-large.md", "Advanced physics covers quantum topics extensively.")
 
             payload = await _wait_for_models({"text-embedding-3-small", "text-embedding-3-large"})
@@ -566,94 +588,8 @@ async def test_search_multi_embedding_models(
             }
             assert {"text-embedding-3-small", "text-embedding-3-large"} <= result_models
     finally:
-        from config.settings import clients
-
+        from config.settings import clients as _clients
         try:
-            await clients.close()
-        except Exception:
-            pass
-
-
-@pytest.mark.parametrize("disable_langflow_ingest", [True, False])
-@pytest.mark.asyncio
-async def test_router_upload_ingest_traditional(tmp_path: Path, disable_langflow_ingest: bool):
-    """Exercise the router endpoint to ensure it routes to traditional upload when Langflow ingest is disabled."""
-    os.environ["DISABLE_INGEST_WITH_LANGFLOW"] = "true" if disable_langflow_ingest else "false"
-    os.environ["DISABLE_STARTUP_INGEST"] = "true"
-    os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
-    os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
-
-    import sys
-    for mod in [
-        "api.router",
-        "api.connector_router",
-        "config.settings",
-        "auth_middleware",
-        "main",
-        "api",
-        "services",
-        "services.search_service",
-    ]:
-        sys.modules.pop(mod, None)
-    from main import create_app, startup_tasks
-    import api.router as upload_router
-    from config.settings import clients, get_index_name, DISABLE_INGEST_WITH_LANGFLOW
-
-    # Ensure a clean index before startup
-    await clients.initialize()
-    try:
-        await clients.opensearch.indices.delete(index=get_index_name())
-        # Wait for deletion to complete
-        await asyncio.sleep(1)
-    except Exception:
-        pass
-
-    app = await create_app()
-    await startup_tasks(app.state.services)
-
-    # Ensure index exists for tests (startup_tasks only creates it if DISABLE_INGEST_WITH_LANGFLOW=True)
-    from main import _ensure_opensearch_index
-    await _ensure_opensearch_index()
-
-    # Verify index is truly empty after startup
-    try:
-        count_response = await clients.opensearch.count(index=get_index_name())
-        doc_count = count_response.get('count', 0)
-        assert doc_count == 0, f"Index should be empty after startup but contains {doc_count} documents"
-    except Exception as e:
-        # If count fails, the index might not exist yet, which is fine
-        pass
-    transport = httpx.ASGITransport(app=app)
-    try:
-        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-            await wait_for_service_ready(client)
-
-            file_path = tmp_path / "router_test_doc.md"
-            file_path.write_text("# Router Test\n\nThis file validates the upload router.")
-
-            files = {
-                "file": (
-                    file_path.name,
-                    file_path.read_bytes(),
-                    "text/markdown",
-                )
-            }
-
-            resp = await client.post("/router/upload_ingest", files=files)
-            data = resp.json()
-
-            print(f"data: {data}")
-            if disable_langflow_ingest:
-                assert resp.status_code == 201 or resp.status_code == 202, resp.text
-                assert data.get("status") in {"indexed", "unchanged"}
-                assert isinstance(data.get("id"), str)
-            else:
-                assert resp.status_code == 201 or resp.status_code == 202, resp.text
-                assert isinstance(data.get("task_id"), str)
-                assert data.get("file_count") == 1
-    finally:
-        from config.settings import clients
-        try:
-            await clients.close()
+            await _clients.close()
         except Exception:
             pass

--- a/tests/integration/test_startup_ingest.py
+++ b/tests/integration/test_startup_ingest.py
@@ -5,11 +5,12 @@ from pathlib import Path
 import httpx
 import pytest
 
-# Files to exclude from ingestion (should match src/main.py)
+from tests.integration.conftest import reload_settings
+
 EXCLUDED_INGESTION_FILES = {"warmup_ocr.pdf"}
 
 
-async def wait_for_ready(client: httpx.AsyncClient, timeout_s: float = 30.0):
+async def wait_for_ready(client: httpx.AsyncClient, timeout_s: float = 60.0):
     deadline = asyncio.get_event_loop().time() + timeout_s
     last_err = None
     while asyncio.get_event_loop().time() < deadline:
@@ -32,37 +33,29 @@ def count_files_in_documents() -> int:
     base_dir = Path(os.getcwd()) / "openrag-documents"
     if not base_dir.is_dir():
         return 0
-    return sum(1 for _ in base_dir.rglob("*") if _.is_file() and _.name not in EXCLUDED_INGESTION_FILES)
-
-
-@pytest.mark.parametrize("disable_langflow_ingest", [True, False])
-@pytest.mark.asyncio
-async def test_startup_ingest_creates_task(disable_langflow_ingest: bool):
-    # Ensure startup ingest runs and choose pipeline per param
-    os.environ["DISABLE_STARTUP_INGEST"] = "false"
-    os.environ["DISABLE_INGEST_WITH_LANGFLOW"] = (
-        "true" if disable_langflow_ingest else "false"
+    return sum(
+        1 for f in base_dir.rglob("*")
+        if f.is_file() and f.name not in EXCLUDED_INGESTION_FILES
     )
-    # Force no-auth mode for simpler endpoint access
-    os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
-    os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
 
-    # Reload settings to pick up env for this test run
-    import sys
 
-    for mod in [
-        "api.router",
-        "api.connector_router",
-        "config.settings",
-        "auth_middleware",
-        "main",
-    ]:
-        sys.modules.pop(mod, None)
+# ---------------------------------------------------------------------------
+# SECTION: Startup
+# ---------------------------------------------------------------------------
 
-    from main import create_app, startup_tasks
-    from config.settings import clients, get_index_name
+@pytest.mark.section_startup
+@pytest.mark.parametrize("disable_langflow_ingest", [True, False])
+async def test_startup_ingest_creates_task(disable_langflow_ingest: bool):
+    ctx = reload_settings({
+        "DISABLE_STARTUP_INGEST": "false",
+        "DISABLE_INGEST_WITH_LANGFLOW": "true" if disable_langflow_ingest else "false",
+    })
+    clients = ctx["clients"]
+    create_app = ctx["create_app"]
+    startup_tasks = ctx["startup_tasks"]
+    ensure_index = ctx["_ensure_opensearch_index"]
+    get_index_name = ctx["get_index_name"]
 
-    # Ensure a clean index before startup
     await clients.initialize()
     try:
         await clients.opensearch.indices.delete(index=get_index_name())
@@ -70,12 +63,8 @@ async def test_startup_ingest_creates_task(disable_langflow_ingest: bool):
         pass
 
     app = await create_app()
-    # Trigger startup tasks explicitly
     await startup_tasks(app.state.services)
-
-    # Ensure index exists for tests (startup_tasks only creates it if DISABLE_INGEST_WITH_LANGFLOW=True)
-    from main import _ensure_opensearch_index
-    await _ensure_opensearch_index()
+    await ensure_index()
 
     transport = httpx.ASGITransport(app=app)
     try:
@@ -84,7 +73,6 @@ async def test_startup_ingest_creates_task(disable_langflow_ingest: bool):
 
             expected_files = count_files_in_documents()
 
-            # Poll /tasks until we see at least one startup ingest task
             async def _wait_for_task(timeout_s: float = 60.0):
                 deadline = asyncio.get_event_loop().time() + timeout_s
                 last = None
@@ -101,9 +89,8 @@ async def test_startup_ingest_creates_task(disable_langflow_ingest: bool):
 
             tasks = await _wait_for_task()
             if expected_files == 0:
-                return  # Nothing to do
+                return
             if not (isinstance(tasks, list) and len(tasks) > 0):
-                # Fallback: verify that documents were indexed as a sign of startup ingest
                 sr = await client.post("/search", json={"query": "*", "limit": 1})
                 assert sr.status_code == 200, sr.text
                 total = sr.json().get("total")
@@ -113,9 +100,8 @@ async def test_startup_ingest_creates_task(disable_langflow_ingest: bool):
             assert "task_id" in newest
             assert newest.get("total_files") == expected_files
     finally:
-        # Explicitly close global clients to avoid aiohttp warnings
-        from config.settings import clients
+        from config.settings import clients as _clients
         try:
-            await clients.close()
+            await _clients.close()
         except Exception:
             pass


### PR DESCRIPTION
This pull request introduces improvements to integration testing, focusing on test isolation, organization, and configuration. The main enhancements include new pytest markers and Makefile targets for running specific integration test sections, centralizing common test setup logic for integration tests, and updating test configuration for better async support.

Integration test organization and isolation:

* Added new pytest markers (`section_upload`, `section_search`, `section_startup`, `section_langflow`) and corresponding Makefile targets to allow running specific subsets of integration tests independently. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R46-R56) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R622-R637)
* Introduced `tests/integration/conftest.py` with fixtures (`fresh_app`, `clean_index`, `test_http_client`) to centralize and automate app creation, environment setup, and index cleanup for integration tests, reducing boilerplate and improving test isolation.

Test configuration improvements:

* Updated pytest configuration in `pyproject.toml` to enable automatic asyncio mode and set test paths, improving async test reliability and clarity.
* Removed the custom `event_loop` fixture from `tests/conftest.py` in favor of pytest's built-in async handling.

Integration test refactoring:

* Refactored `test_startup_ingest.py` to use the new centralized fixtures and helpers, simplifying test logic and ensuring consistent environment setup and teardown. [[1]](diffhunk://#diff-c66792e553a80064c57788c53edef0923857f073335114a96259eb93d39d38f5L8-R13) [[2]](diffhunk://#diff-c66792e553a80064c57788c53edef0923857f073335114a96259eb93d39d38f5L35-R67) [[3]](diffhunk://#diff-c66792e553a80064c57788c53edef0923857f073335114a96259eb93d39d38f5L87) [[4]](diffhunk://#diff-c66792e553a80064c57788c53edef0923857f073335114a96259eb93d39d38f5L104-L106) [[5]](diffhunk://#diff-c66792e553a80064c57788c53edef0923857f073335114a96259eb93d39d38f5L116-R105)

These changes make integration tests easier to maintain, more reliable, and more flexible to run in isolation or as a suite.
______
# Debug just upload issues
make test-integration-upload

# Debug just search issues
make test-integration-search

# Debug just startup ingest
make test-integration-startup

# Or use pytest markers directly
uv run pytest tests/integration/ -m "section_upload and not section_search" -vv -s