### PR TITLE
fix: release workflow to detect version change

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Extract version from pyproject.toml
         id: version


### PR DESCRIPTION
This pull request updates the release workflow to prevent unnecessary releases when the version line in `pyproject.toml` hasn't changed. The workflow now checks for changes to the version and skips the release process if no update is detected.

**Release workflow improvements:**

* Added logic to compare the `version` line in `pyproject.toml` between the previous and current commit, and set a `version_changed` output accordingly to determine if a release should proceed.
* If the version line is unchanged, the workflow sets `skip_release` and `is_prerelease` outputs to `true` and exits early, preventing an unnecessary release.