### PR TITLE
fix: Pin actions/github-script to specific SHA

### DIFF
--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
     steps:
       - name: Manage LGTM Review Label
-        uses: actions/github-script@v8.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             try {

--- a/.github/workflows/auto-delete-branch.yml
+++ b/.github/workflows/auto-delete-branch.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Delete merged branch
-        uses: actions/github-script@v8.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const branchName = context.payload.pull_request.head.ref;


### PR DESCRIPTION
Replace the tag reference (v8.0) with a full commit SHA for actions/github-script in .github/workflows/add-labels.yml and .github/workflows/auto-delete-branch.yml (ed597411d8f924073f98dfc5c65a23a2325f34cd, comment notes v8.0.0). This pins the action to an exact revision to ensure reproducible, stable workflow runs and avoid unexpected changes from tag updates.