### PR TITLE
fix: Extend update-uv-lock workflow to SDKs

### DIFF
--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'pyproject.toml'
+      - 'sdks/python/pyproject.toml'
+      - 'sdks/mcp/pyproject.toml'
   workflow_dispatch:
 
 jobs:
@@ -30,15 +32,23 @@ jobs:
       - name: Update uv.lock
         run: uv sync
 
+      - name: Update sdks/python/uv.lock
+        working-directory: sdks/python
+        run: uv sync
+
+      - name: Update sdks/mcp/uv.lock
+        working-directory: sdks/mcp
+        run: uv sync
+
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet uv.lock; then
+          if git diff --quiet uv.lock sdks/python/uv.lock sdks/mcp/uv.lock; then
             echo "changed=false" >> $GITHUB_OUTPUT
-            echo "No changes to uv.lock"
+            echo "No changes to uv.lock files"
           else
             echo "changed=true" >> $GITHUB_OUTPUT
-            echo "uv.lock has been updated"
+            echo "uv.lock files have been updated"
           fi
 
       - name: Commit and push uv.lock
@@ -46,7 +56,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git add uv.lock
-          git commit -m "chore: update uv.lock after version bump [skip ci]"
+          git add uv.lock sdks/python/uv.lock sdks/mcp/uv.lock
+          git commit -m "chore: update uv.lock files after version bump [skip ci]"
           git push
 


### PR DESCRIPTION
Include sdks/python and sdks/mcp in the update-uv-lock workflow: add their pyproject.toml to the workflow triggers, run `uv sync` in each SDK directory, and include their uv.lock files in the change detection and commit steps. Update messages and commit text to reference the multiple uv.lock files so SDK lockfiles are kept in sync on version bumps.