### PR TITLE
fix: Update uvx invocation and docling extras

### DIFF
--- a/src/tui/managers/docling_manager.py
+++ b/src/tui/managers/docling_manager.py
@@ -295,6 +295,7 @@ class DoclingManager:
                 "--with", "onnxruntime",
                 "--with", "easyocr",
                 "--with", f"docling[{docling_extras}]",
+                "--with", "docling-core==2.48.1",
             ]
             if override_path:
                 cmd += ["--override", override_path, "--with", "opencv-python-headless"]


### PR DESCRIPTION
Replace the single-platform ocr_pkg with a platform-aware docling_extras string and expand the uvx command to explicitly include onnxruntime, easyocr and docling extras (rapidocr, vlm, ocrmac on macOS). Move the UI-pinned spec into a --from argument and stop pinning docling-serve in the package list. These changes ensure the required runtimes and optional backends are requested during installation and clarify the package sourcing.