### PR TITLE
feat: Re-affirm Python 3.13 minimum version required for OpenRAG app via PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,18 @@ version = "0.2.5"
 description = "OpenRAG is a comprehensive Retrieval-Augmented Generation platform that enables intelligent document search and AI-powered conversations."
 readme = "README.md"
 requires-python = ">=3.13"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
 dependencies = [
     "agentd>=0.2.2",
     "aiofiles>=24.1.0",

--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -12,9 +12,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
     "mcp>=1.0.0",

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -17,10 +17,12 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]


### PR DESCRIPTION
## Issues

- #1023

## Summary

Updated PyPI classifiers across core package and SDKs

## Package Metadata

- Added classifiers block to the root pyproject.toml, including development status, environment, audience, license, Python version, and topic classifiers
- Added "Programming Language :: Python :: 3 :: Only" classifier to the MCP SDK and Python SDK pyproject.toml files to explicitly indicate Python 3 exclusivity
- Added "Programming Language :: Python :: 3.13" classifier to the MCP SDK to reflect supported version coverage
- Added "Topic :: Scientific/Engineering :: Artificial Intelligence" classifier to the MCP SDK and Python SDK
- Added "Topic :: Software Development :: Libraries :: Python Modules" classifier to the MCP SDK
