### PR TITLE
ci: remove [skip ci] from uv.lock workflow to fix release publishing

### DIFF
--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -63,6 +63,6 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add uv.lock sdks/python/uv.lock sdks/mcp/uv.lock
-          git commit -m "chore: update uv.lock files after version bump [skip ci]"
+          git commit -m "chore: update uv.lock files after version bump"
           git push
 


### PR DESCRIPTION
## Summary

- Removes `[skip ci]` from the automated commit message in the `update-uv-lock.yml` workflow

## Problem

The release 0.2.5 merge to `main` (#1021) did **not** trigger the MCP, Python SDK, or TypeScript SDK publish workflows, even though the commit modified all three trigger paths (`sdks/mcp/pyproject.toml`, `sdks/python/pyproject.toml`, `sdks/typescript/package.json`).

**Root cause:** When PR #1021 was squash-merged, GitHub concatenated all intermediate commit messages into the squash commit body. One of those was the automated uv.lock update commit:

```
chore: update uv.lock files after version bump [skip ci]
```

GitHub Actions scans the **entire** commit message (title + body) for `[skip ci]`. Finding it in the body caused GitHub to skip **all** workflows for that push — including the three publish workflows.

## Why this fix is safe

The `[skip ci]` was originally added to prevent the uv.lock commit from re-triggering the `update-uv-lock` workflow in a loop. However, this is unnecessary because the workflow already uses a `paths` filter that only matches `pyproject.toml` files:

```yaml
paths:
  - 'pyproject.toml'
  - 'sdks/python/pyproject.toml'
  - 'sdks/mcp/pyproject.toml'
```

A commit that only modifies `uv.lock` files will never match this filter, so no infinite loop is possible.
