### PR TITLE
fix: Adjust asset resource lookup and set .env path

### DIFF
--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -482,11 +482,24 @@ def copy_sample_documents(*, force: bool = False) -> None:
     documents_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        assets_files = files("tui._assets.openrag-documents")
+        assets_files = files("tui._assets") / "openrag-documents"
         _copy_assets(assets_files, documents_dir, allowed_suffixes=(".pdf",), force=force)
     except Exception as e:
         logger.debug(f"Could not copy sample documents: {e}")
         # This is not a critical error - the app can work without sample documents
+
+    # Ensure OPENRAG_DOCUMENTS_PATH in .env points to the resolved documents directory.
+    # Docker Compose uses this for the volume mount; if unset it defaults to ./openrag-documents
+    # (CWD-relative), which may not contain the PDFs copied above.
+    try:
+        from dotenv import set_key
+        resolved_path = str(documents_dir.resolve())
+        current = env_manager.config.openrag_documents_path
+        if not current or current in ("$HOME/.openrag/documents", "./openrag-documents", "./documents"):
+            set_key(str(env_manager.env_file), "OPENRAG_DOCUMENTS_PATH", resolved_path)
+            logger.debug(f"Set OPENRAG_DOCUMENTS_PATH={resolved_path} in {env_manager.env_file}")
+    except Exception as e:
+        logger.debug(f"Could not update OPENRAG_DOCUMENTS_PATH in .env: {e}")
 
 
 def copy_sample_flows(*, force: bool = False) -> None:
@@ -501,7 +514,7 @@ def copy_sample_flows(*, force: bool = False) -> None:
     flows_dir.mkdir(parents=True, exist_ok=True)
 
     try:
-        assets_files = files("tui._assets.flows")
+        assets_files = files("tui._assets") / "flows"
         _copy_assets(assets_files, flows_dir, allowed_suffixes=(".json",), force=force)
     except Exception as e:
         logger.debug(f"Could not copy sample flows: {e}")


### PR DESCRIPTION
Use the package assets root (files("tui._assets") / "subdir") when locating sample documents and flows instead of the previous dotted resource path. Add logic to persist the resolved documents directory into OPENRAG_DOCUMENTS_PATH in the .env file (via dotenv.set_key) when the config is empty or still set to common defaults, so Docker Compose volume mounts point to the actual copied PDFs. All writes are guarded with try/except and logged as debug to avoid breaking startup on failure.


_________________
This pull request updates the logic for copying sample documents and flows in `src/tui/main.py` to improve asset discovery and environment configuration. The changes ensure that assets are found correctly and that the application's environment is set up more robustly, particularly for Docker Compose deployments.

**Asset discovery improvements:**

* Changed how asset files are located by updating the usage of `files()` to reference the parent `tui._assets` directory and then access subdirectories with `/ "openrag-documents"` and `/ "flows"`. This makes asset discovery more reliable and compatible with the latest importlib resources API. [[1]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL485-R503) [[2]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL504-R517)

**Environment configuration enhancements:**

* Added logic to automatically update the `OPENRAG_DOCUMENTS_PATH` variable in the `.env` file to the resolved documents directory if it is unset or set to a default value. This helps Docker Compose mount the correct volume and ensures the application can always find the sample documents.