### PR TITLE
refactor: update settings alignment

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1088,7 +1088,7 @@ function ChatPage() {
       )}
 
       <StickToBottom.Content className="flex flex-col min-h-full overflow-x-hidden p-6">
-        <div className="flex flex-col place-self-center space-y-6 max-w-[960px] w-full mx-auto">
+        <div className="flex flex-col place-self-center space-y-6 max-w-content w-full mx-auto">
           {messages.length === 0 && !streamingMessage ? (
             <div className="flex items-center justify-center h-full text-muted-foreground">
               <div className="text-center">
@@ -1209,7 +1209,7 @@ function ChatPage() {
           )}
         </div>
       </StickToBottom.Content>
-      <div className="p-6 pt-0 max-w-[960px] mx-auto w-full">
+      <div className="p-6 pt-0 max-w-content mx-auto w-full">
         {/* Input Area - Fixed at bottom */}
         <ChatInput
           ref={chatInputRef}

--- a/frontend/components/chat-renderer.tsx
+++ b/frontend/components/chat-renderer.tsx
@@ -301,7 +301,7 @@ export function ChatRenderer({
             className={cn(
               "h-full bg-background w-full",
               showLayout && !isOnChatPage && "p-6 container",
-              showLayout && isSmallWidthPath && "max-w-[920px] ml-0",
+              showLayout && isSmallWidthPath && "max-w-content mx-auto",
               !showLayout && "p-0 py-2",
             )}
           >

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -21,6 +21,9 @@ const config = {
       },
     },
     extend: {
+      maxWidth: {
+        content: "960px",
+      },
       screens: {
         xl: "1200px",
         "2xl": "1400px",


### PR DESCRIPTION
Centers settings to match chat and KB

Before:
<img width="1371" height="1148" alt="Screenshot 2026-03-05 at 10 59 40 AM" src="https://github.com/user-attachments/assets/23a2e0ba-4ed7-42b3-a3ab-5f04d7354b0c" />

After:
<img width="1748" height="1132" alt="Screenshot 2026-03-05 at 10 59 52 AM" src="https://github.com/user-attachments/assets/89b7771e-7ac7-443d-bc7f-44b177a52050" />
