### PR TITLE
feat: Update CI runner labels to ephemeral

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -20,7 +20,8 @@ on:
 
 jobs:
   tests:
-    runs-on: [self-hosted, linux, ARM64, langflow-ai-arm64-40gb]
+    runs-on:
+      labels: ["self-hosted", "linux", "ARM64", "langflow-ai-arm64-40gb-ephemeral"]
     env:
       # Prefer repository/environment variable first, then secret, then a sane fallback
       OPENSEARCH_PASSWORD: ${{ vars.OPENSEARCH_PASSWORD || secrets.OPENSEARCH_PASSWORD || 'OpenRag#2025!' }}


### PR DESCRIPTION
Switch runs-on from an array to a labels mapping and update the self-hosted runner label to "langflow-ai-arm64-40gb-ephemeral". This ensures the workflow targets the ephemeral ARM64 self-hosted runner while leaving existing environment variables unchanged.
___________________
This pull request updates the configuration for the integration test workflow to improve runner selection. The change clarifies and refines the runner label used for the `tests` job in the GitHub Actions workflow.

Workflow configuration update:

* Changed the `runs-on` specification in `.github/workflows/test-integration.yml` to use a `labels` array with the more specific `langflow-ai-arm64-40gb-ephemeral` label, which helps ensure tests run on the intended ephemeral runner environment.