### PR TITLE
fix: persist Langflow database across container restarts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,11 @@ OPENSEARCH_PASSWORD=
 # Default: ./opensearch-data
 OPENSEARCH_DATA_PATH=./opensearch-data
 
+# Path to persist Langflow database and state (flows, credentials, settings)
+# Without this volume, flow edits will be lost on container restart
+# Default: ./langflow-data
+LANGFLOW_DATA_PATH=./langflow-data
+
 # OpenSearch Connection
 OPENSEARCH_HOST=opensearch
 OPENSEARCH_PORT=9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,6 +119,7 @@ services:
   langflow:
     volumes:
       - ${OPENRAG_FLOWS_PATH:-./flows}:/app/flows:U,z
+      - ${LANGFLOW_DATA_PATH:-./langflow-data}:/root/.langflow:U,z
     image: langflowai/openrag-langflow:${OPENRAG_VERSION:-latest}
     build:
       context: .
@@ -138,6 +139,7 @@ services:
       - WATSONX_PROJECT_ID=${WATSONX_PROJECT_ID}
       - OLLAMA_BASE_URL=${OLLAMA_ENDPOINT}
       - LANGFLOW_LOAD_FLOWS_PATH=/app/flows
+      - LANGFLOW_DATABASE_URL=sqlite:////root/.langflow/langflow.db
       - LANGFLOW_SECRET_KEY=${LANGFLOW_SECRET_KEY}
       - JWT=None
       - OWNER=None


### PR DESCRIPTION
## Summary
Fixes #1127 - Langflow flow edits were being lost after container restart.

## Problem
The `langflow` service in docker-compose.yml only mounted `/app/flows` for flow files, but Langflow stores its SQLite database at `/root/.langflow/` by default. This directory was ephemeral, causing all flow edits to be lost on container restart.

## Solution
1. **Add persistent volume** for Langflow data directory:
   - Mount `${LANGFLOW_DATA_PATH:-./langflow-data}` to `/root/.langflow`
   
2. **Explicitly set database location** via `LANGFLOW_DATABASE_URL`:
   - `sqlite:////root/.langflow/langflow.db`
   - Ensures database is always in the mounted volume

3. **Document new environment variable** in `.env.example`:
   - `LANGFLOW_DATA_PATH=./langflow-data`

## Changes
| File | Change |
|------|--------|
| `docker-compose.yml` | Added volume mount for `/root/.langflow` + `LANGFLOW_DATABASE_URL` env var |
| `.env.example` | Added `LANGFLOW_DATA_PATH` documentation |

## Testing
- Configuration verified against Langflow documentation
- Volume mount follows same pattern as existing `OPENSEARCH_DATA_PATH`

## Backward Compatibility
- Fully backward compatible - existing deployments will work unchanged
- New volume is optional (defaults to `./langflow-data`)

Closes #1127