### PR TITLE
fix: Google drive connector issues

### DIFF
--- a/flows/openrag_nudges.json
+++ b/flows/openrag_nudges.json
@@ -2822,7 +2822,7 @@
                 "title_case": false,
                 "track_in_telemetry": false,
                 "type": "str",
-                "value": "8$8@SqVR&ZvbGBrd"
+                "value": ""
               },
               "request_timeout": {
                 "_input_type": "StrInput",


### PR DESCRIPTION
Root cause was in auth state, not the upload page UI.

Google connection was being marked unauthenticated because token expiry was interpreted incorrectly (timezone-naive handling), so authenticate() returned False.

The current Google token file also has no refresh_token, so once access token expires it cannot auto-refresh.
I patched this end-to-end:

-Normalized stored OAuth expiry to naive UTC at load time (compatible with google-auth): oauth.py 

-Saved callback expiry in UTC and preserve existing refresh_token when provider omits it on re-consent.

-Added Google OAuth params to request offline refresh token consistently (include_granted_scopes=true, prompt=consent) in both login and connector connect flows)

-Made some changes in UI, so Mike needs to validate.