### PR TITLE
feat: added nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -165,8 +165,8 @@ jobs:
           import re
           with open('pyproject.toml', 'r') as f:
               content = f.read()
-          # Append .dev + run_number to the version (PEP 440 compliant)
-          new_content = re.sub(r'^version = \"([^\"]+)\"', r'version = \"\1.dev${{ github.run_number }}\"', content, flags=re.M)
+          # Append .dev + run_number + run_attempt to the version (PEP 440 compliant and unique per attempt)
+          new_content = re.sub(r'^version = \"([^\"]+)\"', r'version = \"\1.dev${{ github.run_number }}${{ github.run_attempt }}\"', content, flags=re.M)
           with open('pyproject.toml', 'w') as f:
               f.write(new_content)
           "


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate nightly Docker image builds and nightly Python package publishing. The workflow schedules multi-architecture builds for backend, frontend, and langflow services, manages Docker image versioning and tagging, and publishes a nightly build of the Python package to PyPI.

**CI/CD Automation Enhancements:**

* Added `.github/workflows/nightly-build.yml` to automate nightly Docker builds for backend, frontend, and langflow services, supporting both `amd64` and `arm64` architectures, with scheduled and manual triggers.
* Implemented dynamic versioning for nightly builds using the current date, GitHub run number, and run attempt to ensure uniqueness and traceability of Docker images and Python packages.
* Configured multi-architecture Docker image manifest creation and tagging, including updating a floating `nightly` tag for each service.
* Automated nightly publishing of the Python package to PyPI, appending a `.dev` suffix to the version for compliance and uniqueness.