### PR TITLE
fix: made nightly build to push always to langflowai

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -92,7 +92,7 @@ jobs:
           file: ${{ matrix.file }}
           platforms: ${{ matrix.platform }}
           push: true
-          tags: ${{ secrets.DOCKER_NAMESPACE }}/${{ matrix.service }}:${{ needs.check-version.outputs.nightly_version }}-${{ matrix.arch }}
+          tags: langflowai/${{ matrix.service }}:${{ needs.check-version.outputs.nightly_version }}-${{ matrix.arch }}
           cache-from: type=gha,scope=nightly-${{ matrix.image }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=nightly-${{ matrix.image }}-${{ matrix.arch }}
 
@@ -124,7 +124,7 @@ jobs:
 
       - name: Create and push multi-arch manifests
         run: |
-          NS=${{ secrets.DOCKER_NAMESPACE }}
+          NS="langflowai"
           VERSION=${{ needs.check-version.outputs.nightly_version }}
 
           # Derive the list of services from the artifacts produced by the build matrix


### PR DESCRIPTION
This pull request updates the Docker image publishing process in the nightly build workflow. The main change is switching from using a secret-based Docker namespace to a hardcoded `langflowai` namespace for both image tags and multi-arch manifest creation.

**Docker Namespace Standardization:**

* Updated the Docker image tags in the build matrix to use the `langflowai` namespace instead of the value from the `DOCKER_NAMESPACE` secret in `.github/workflows/nightly-build.yml`.
* Changed the multi-arch manifest creation step to set the namespace as `langflowai` instead of using the `DOCKER_NAMESPACE` secret in `.github/workflows/nightly-build.yml`.