### PR TITLE
feat: release 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag"
-version = "0.3.1"
+version = "0.3.2"
 description = "OpenRAG is a comprehensive Retrieval-Augmented Generation platform that enables intelligent document search and AI-powered conversations."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "MCP server for OpenRAG"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sdks/mcp/src/openrag_mcp/__init__.py
+++ b/sdks/mcp/src/openrag_mcp/__init__.py
@@ -2,6 +2,6 @@
 
 from openrag_mcp.server import main
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __all__ = ["main"]
 

--- a/sdks/mcp/uv.lock
+++ b/sdks/mcp/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "openrag-mcp"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/python/openrag_sdk/__init__.py
+++ b/sdks/python/openrag_sdk/__init__.py
@@ -68,7 +68,7 @@ from .models import (
     UpdateKnowledgeFilterOptions,
 )
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 __all__ = [
     # Main client

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag-sdk"
-version = "0.2.1"
+version = "0.2.2"
 description = "Official Python SDK for OpenRAG API"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "openrag-sdk"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrag-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrag-sdk",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrag-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Official TypeScript/JavaScript SDK for OpenRAG API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/uv.lock
+++ b/uv.lock
@@ -1253,7 +1253,7 @@ wheels = [
 
 [[package]]
 name = "openrag"
-version = "0.3.1"
+version = "0.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "agentd" },


### PR DESCRIPTION
This pull request updates the version numbers for the main OpenRAG project and its related SDKs, reflecting a new release across Python and TypeScript packages. No functional or code changes are included; these are purely version bumps to ensure consistency and proper release tracking.

Version updates:

* Main OpenRAG project: Bumped version from `0.3.1` to `0.3.2` in `pyproject.toml`
* Python SDKs:
  * [`openrag-sdk`](diffhunk://#diff-9d9609083fe7cffbd6a565ebdf77f87d75c7b014d4b0b20d767af88e2f142d59L7-R7): Updated version from `0.2.1` to `0.2.2` in `sdks/python/pyproject.toml` and `sdks/python/openrag_sdk/__init__.py` [[1]](diffhunk://#diff-9d9609083fe7cffbd6a565ebdf77f87d75c7b014d4b0b20d767af88e2f142d59L7-R7) [[2]](diffhunk://#diff-97ad3d3eb051c599cdd9a06aaa023aefa49f469d6171a3ef25669e16517a0e22L71-R71)
  * [`openrag-mcp`](diffhunk://#diff-627e9ddd65b86c7b30f9a296628fd1e79da9ec3726fa606d79a1a9c91b025131L3-R3): Updated version from `0.2.1` to `0.2.2` in `sdks/mcp/pyproject.toml` and `sdks/mcp/src/openrag_mcp/__init__.py` [[1]](diffhunk://#diff-627e9ddd65b86c7b30f9a296628fd1e79da9ec3726fa606d79a1a9c91b025131L3-R3) [[2]](diffhunk://#diff-5758eb0ff4b88415ea9c329bd6cae5a9f18075e6dcf8b06dba5bfed7f238a821L5-R5)
* TypeScript SDK:
  * [`openrag-sdk`](diffhunk://#diff-6529d74368166eff0bc97e1a4098ba6b39c59877ab029d04fdc002c9cc034c38L3-R3): Updated version from `0.2.1` to `0.2.2` in `sdks/typescript/package.json` and `sdks/typescript/package-lock.json` [[1]](diffhunk://#diff-6529d74368166eff0bc97e1a4098ba6b39c59877ab029d04fdc002c9cc034c38L3-R3) [[2]](diffhunk://#diff-9b6e579e6fa8b3e3459567b0edae1474eac78a6437547e8594730ca6556400a2L3-R9)