### PR TITLE
fix: remove hardcoded host.docker.internal default for DOCLING_SERVE_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
       - OPENSEARCH_PORT=${OPENSEARCH_PORT:-9200}
       - OPENSEARCH_URL=https://${OPENSEARCH_HOST:-opensearch}:${OPENSEARCH_PORT:-9200}
       - OPENSEARCH_INDEX_NAME=${OPENSEARCH_INDEX_NAME:-documents}
-      - DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-http://host.docker.internal:5001}
+      - DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-}
       - FILENAME=None
       - MIMETYPE=None
       - FILESIZE=0


### PR DESCRIPTION
## Summary

The hardcoded default `http://host.docker.internal:5001` prevents the container-aware auto-detection logic in `docling.py` from running. This causes failures in pure WSL2 Docker environments where `host.docker.internal` doesn't resolve.

## Problem

When running `uvx openrag` in a pure WSL2 environment with native Docker engine:

1. `docker-compose.yml` sets `DOCLING_SERVE_URL=http://host.docker.internal:5001` as the default
2. Pure WSL Docker does not resolve `host.docker.internal`
3. The backend's `determine_docling_host()` function (which handles WSL via gateway IP fallback) is never called because the env var override takes precedence
4. Result: continuous 503 errors, UI blocked at onboarding

## Fix

Now `DOCLING_SERVE_URL` defaults to empty, allowing `determine_docling_host()` to auto-detect the correct host based on the environment (Docker Desktop, WSL2, containers, etc.). Users can still override with environment variable.

Fixes langflow-ai/openrag#1178