### PR TITLE
fix: change tag logic and verbose uv publish

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -249,6 +249,7 @@ jobs:
 
       - name: Publish to PyPI
         run: |
-          uv publish
+          set -euo pipefail
+          uv publish --verbose
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}

--- a/scripts/ci/pypi_nightly_tag.py
+++ b/scripts/ci/pypi_nightly_tag.py
@@ -5,9 +5,6 @@ from pathlib import Path
 import tomllib
 from typing import Optional
 
-PYPI_OPENRAG_NIGHTLY_URL = "https://pypi.org/pypi/openrag-nightly/json"
-PYPI_OPENRAG_URL = "https://pypi.org/pypi/openrag/json"
-
 def get_latest_published_version(project_name: str) -> Optional[Version]:
     url = f"https://pypi.org/pypi/{project_name}/json"
     try:
@@ -32,32 +29,21 @@ def create_tag():
     local_version_str = pyproject_data["project"]["version"]
     local_version = Version(local_version_str)
 
-    # Check both projects on PyPI
+    # Check PyPI for the latest published stable version
     pypi_main = get_latest_published_version("openrag")
-    pypi_nightly = get_latest_published_version("openrag-nightly")
 
-    # Find the absolute latest version between local and both pypi versions
+    # Find the highest version between local and PyPI
     # We use this as a reference point for the dev suffix
-    versions_to_check = [v for v in [local_version, pypi_main, pypi_nightly] if v is not None]
+    versions_to_check = [v for v in [local_version, pypi_main] if v is not None]
     latest_known_version = max(versions_to_check)
 
-    build_number = 0
+    build_number = 1  # dev builds start at .dev1
     base_version = local_version.base_version
 
-    # If the latest version on PyPI matches our local base version (or is higher),
-    # we need to increment the dev suffix.
+    # If the latest known version shares the same base, increment from its dev suffix
     if latest_known_version.base_version == base_version:
         if latest_known_version.dev is not None:
             build_number = latest_known_version.dev + 1
-        else:
-            # If the latest is a stable release (no dev suffix), we still need to
-            # increment because you shouldn't have dev releases for an already released version
-            # However, PEP 440 doesn't strictly forbid 0.3.2.dev0 if 0.3.2 already exists,
-            # but usually you'd move to the next minor/patch.
-            # For now, let's keep the dev0 for the next version if possible?
-            # Actually, standard practice for nightlies if base version is out: move to next patch.
-            # But we respect the version in pyproject.toml.
-            build_number = 0
 
     # Build PEP 440-compliant nightly version (without leading "v")
     nightly_version_str = f"{base_version}.dev{build_number}"


### PR DESCRIPTION
This pull request makes improvements to the nightly build and publishing process, primarily focusing on the PyPI nightly version tagging logic and the workflow for publishing to PyPI. The changes simplify and clarify the logic for generating nightly build versions, ensuring compliance with PEP 440, and enhance the publishing step for better reliability and debugging.

**Nightly versioning logic improvements:**

* Simplified version comparison in `pypi_nightly_tag.py` to only check the local and main PyPI versions (removing redundant checks for the nightly version), and clarified how the nightly build number is determined, starting at `.dev1` and incrementing appropriately if a dev build already exists. [[1]](diffhunk://#diff-9178a612fb8e68e13ccacc044eb6329847bed436ba702d2e798494ddf845f1ebL8-L10) [[2]](diffhunk://#diff-9178a612fb8e68e13ccacc044eb6329847bed436ba702d2e798494ddf845f1ebL35-L60)

**Publishing workflow enhancements:**

* Updated the `Publish to PyPI` step in `.github/workflows/nightly-build.yml` to add strict error handling and verbose output for easier debugging and safer publishing.