### PR TITLE
fix: add any_configured() to ProvidersConfig to prevent onboarding 500

### DIFF
--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -49,6 +49,10 @@ class ProvidersConfig:
     watsonx: WatsonXConfig
     ollama: OllamaConfig
 
+    def any_configured(self) -> bool:
+        """Return True if at least one provider is marked as configured."""
+        return any(p.configured for p in (self.openai, self.anthropic, self.watsonx, self.ollama))
+
     def get_provider_config(self, provider: str):
         """Get configuration for a specific provider."""
         provider_lower = provider.lower()


### PR DESCRIPTION
## Summary

Onboarding fails with a 500 error when configuring watsonx.ai or ollama providers because `ProvidersConfig` is missing the `any_configured()` method that `settings.py` calls.

## Problem

`src/api/settings.py` line 1088 calls:
```python
current_config.providers.any_configured()
```

But `ProvidersConfig` in `src/config/config_manager.py` only has `get_provider_config()` — no `any_configured()` method exists. This raises `AttributeError: 'ProvidersConfig' object has no attribute 'any_configured'`, which surfaces as a 500 error during the onboarding settings save.

## Root cause

The `any_configured()` call was added to `settings.py` but the corresponding method was never implemented on the `ProvidersConfig` dataclass.

## Fix

Add `any_configured()` to `ProvidersConfig` that returns `True` if any provider's `configured` flag is set. Each provider dataclass (`OpenAIConfig`, `AnthropicConfig`, `WatsonXConfig`, `OllamaConfig`) already has a `configured: bool` field.

## Testing

- Configuring watsonx.ai or ollama during onboarding no longer crashes with 500
- `any_configured()` returns `True` when at least one provider is configured
- `any_configured()` returns `False` when no providers are configured

Closes #1163