### PR TITLE
fix: Factory reset using TUI fails on Windows 11 (WSL) and Podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -521,7 +521,7 @@ factory-reset: ## Complete reset (stop, remove volumes, clear data, remove image
 	fi; \
 	echo ""; \
 	echo "$(YELLOW)Stopping all services and removing volumes...$(NC)"; \
-	$(COMPOSE_CMD) down -v --remove-orphans --rmi local || true; \
+	$(COMPOSE_CMD) down -v --remove-orphans || true; \
 	echo "$(YELLOW)Removing local data directories...$(NC)"; \
 	if [ -d "opensearch-data" ]; then \
 		echo "Removing opensearch-data..."; \

--- a/docs/docs/_partial-docker-compose-down-and-prune.mdx
+++ b/docs/docs/_partial-docker-compose-down-and-prune.mdx
@@ -4,6 +4,6 @@ docker system prune -f
 ```
 
 ```bash title="Podman"
-podman compose down --volumes --remove-orphans --rmi local
+podman compose down --volumes --remove-orphans
 podman system prune -f
 ```

--- a/src/tui/managers/container_manager.py
+++ b/src/tui/managers/container_manager.py
@@ -1302,7 +1302,7 @@ class ContainerManager:
 
         # Stop and remove everything
         success, stdout, stderr = await self._run_compose_command(
-            ["down", "--volumes", "--remove-orphans", "--rmi", "local"]
+            ["down", "--volumes", "--remove-orphans"]
         )
 
         if not success:


### PR DESCRIPTION
### Issue

- #1203

### Summary

- Removed --rmi local from factory reset commands to fix podman-compose compatibility

### TUI / Container Manager

- Removed unsupported --rmi local flag from the compose down command in reset_services(), which caused factory reset to fail immediately on podman-compose (exit status 2); image cleanup was already handled by the explicit removal step that follows.

### Makefile

- Removed --rmi local from the make factory-reset compose down invocation to eliminate noisy podman-compose error output; the || true fallback was retained to keep the reset idempotent when no containers are running.

### Documentation

- Removed --rmi local from the Podman code snippet in _partial-docker-compose-down-and-prune.mdx to correct the manual reinstall instructions; the Docker snippet was left unchanged as the flag is valid for Docker Compose.