### PR TITLE
feat: Implement a new health check API endpoint for the Frontend app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -982,6 +982,7 @@ status: ## Show container status
 
 health: ## Check health of all services
 	@echo "$(PURPLE)Health check:$(NC)"
+	@echo "$(CYAN)Frontend:$(NC)   $$(curl -s http://localhost:3000/health 2>/dev/null || echo '$(RED)Not responding$(NC)')"
 	@echo "$(CYAN)Backend:$(NC)    $$(curl -s http://localhost:8000/health 2>/dev/null || echo '$(RED)Not responding$(NC)')"
 	@echo "$(CYAN)Langflow:$(NC)   $$(curl -s http://localhost:7860/health 2>/dev/null || echo '$(RED)Not responding$(NC)')"
 	@echo "$(CYAN)OpenSearch:$(NC) $$(curl -s -k -u admin:$${OPENSEARCH_PASSWORD} https://localhost:9200 2>/dev/null | jq -r .tagline 2>/dev/null || echo '$(RED)Not responding$(NC)')"

--- a/frontend/app/health/route.ts
+++ b/frontend/app/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok" }, { status: 200 });
+}


### PR DESCRIPTION
### Issue

- #1221

### Summary

- Added a frontend /health liveness probe endpoint and included it in the make health target.

### Frontend

- Added frontend/app/health/route.ts, a Next.js route handler that returned {"status": "ok"} with HTTP 200 as a liveness probe for the frontend application.

### Makefile

- Updated the health target to call http://localhost:3000/health and display the frontend health status alongside the backend, Langflow, and OpenSearch checks.

---

### Manual Verification Test

```shell
mpawlow@OpenRAG1:~/git/openrag$ make health
Health check:
Frontend:   {"status":"ok"}
Backend:    {"status":"ok"}
Langflow:   {"status":"ok"}
OpenSearch: The OpenSearch Project: https://opensearch.org/
```

