### PR TITLE
feat: Add Dockerfile for docling-serve

### DIFF
--- a/Dockerfile.docling_serve
+++ b/Dockerfile.docling_serve
@@ -1,0 +1,30 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# System deps (needed for OCR + OpenCV)
+RUN apt-get update && apt-get install -y \
+    libglib2.0-0 \
+    libgl1 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install uv (fast package runner)
+RUN pip install --no-cache-dir uv
+
+# Install docling-serve with all extras
+RUN uv pip install \
+    "docling-serve[ui]==1.5.0" \
+    onnxruntime \
+    easyocr \
+    "docling[easyocr,rapidocr,vlm]" \
+    "docling-core==2.48.1" \
+    opencv-python-headless
+
+# Expose port
+EXPOSE 8000
+
+# Start server
+CMD ["docling-serve", "run", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]

--- a/Dockerfile.docling_serve
+++ b/Dockerfile.docling_serve
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
 
 WORKDIR /app
 
@@ -11,11 +11,8 @@ RUN apt-get update && apt-get install -y \
     libxrender-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install uv (fast package runner)
-RUN pip install --no-cache-dir uv
-
 # Install docling-serve with all extras
-RUN uv pip install \
+RUN uv pip install --system \
     "docling-serve[ui]==1.5.0" \
     onnxruntime \
     easyocr \

--- a/Dockerfile.docling_serve
+++ b/Dockerfile.docling_serve
@@ -20,8 +20,17 @@ RUN uv pip install --system \
     "docling-core==2.48.1" \
     opencv-python-headless
 
+# Set global model cache directories so any user running the container can access them
+ENV HF_HOME=/app/models/huggingface \
+    EASYOCR_MODULE_PATH=/app/models/easyocr
+
+# Pre-download all models (EasyOCR, Docling Layout, VLM) into global directories
+RUN mkdir -p /app/models && \
+    python -c "import easyocr; easyocr.Reader(['en']); from docling.document_converter import DocumentConverter; from docling.datamodel.document import InputFormat; converter = DocumentConverter(); converter.format_to_options[InputFormat.PDF].pipeline_options.do_picture_description = True; converter.initialize_pipeline(InputFormat.PDF)" && \
+    chmod -R 777 /app/models
+
 # Expose port
-EXPOSE 8000
+EXPOSE 5001
 
 # Start server
-CMD ["docling-serve", "run", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+CMD ["docling-serve", "run", "--host", "0.0.0.0", "--port", "5001", "--workers", "2", "--enable-ui"]


### PR DESCRIPTION
Add a new Dockerfile (Dockerfile.docling_serve) to run docling-serve in a slim Python 3.11 container. Installs system libraries required for OCR/OpenCV, installs uv as a fast package runner, and uses uv pip to install docling-serve (1.5.0) with UI and OCR extras plus onnxruntime, easyocr, docling-core (2.48.1) and opencv-python-headless. Exposes port 8000 and starts the server on 0.0.0.0:8000 with 2 workers.