### PR TITLE
fix: change navigation to be blocked when switching tabs

### DIFF
--- a/frontend/components/navigation.tsx
+++ b/frontend/components/navigation.tsx
@@ -313,34 +313,45 @@ export function Navigation({
     <div className="flex flex-col h-full bg-background">
       <div className="px-4 py-2 flex-shrink-0">
         <div className="space-y-1">
-          {routes.map((route) => (
-            <div key={route.href}>
-              <Link
-                href={route.href}
-                className={cn(
-                  "text-[13px] group flex p-3 w-full justify-start font-medium cursor-pointer hover:bg-accent hover:text-accent-foreground rounded-lg transition-all",
-                  route.active
-                    ? "bg-accent text-accent-foreground shadow-sm"
-                    : "text-foreground hover:text-accent-foreground",
+          {routes.map((route) => {
+            const isDisabled = loading && !route.active;
+            const tabClassName = cn(
+              "text-[13px] group flex p-3 w-full justify-start font-medium rounded-lg transition-all",
+              isDisabled
+                ? "opacity-50 cursor-not-allowed text-foreground"
+                : "cursor-pointer hover:bg-accent hover:text-accent-foreground",
+              route.active
+                ? "bg-accent text-accent-foreground shadow-sm"
+                : "text-foreground",
+            );
+            const tabContent = (
+              <div className="flex items-center flex-1">
+                <route.icon
+                  className={cn(
+                    "h-[18px] w-[18px] mr-2 shrink-0",
+                    route.active
+                      ? "text-muted-foreground"
+                      : "text-muted-foreground group-hover:text-muted-foreground",
+                  )}
+                />
+                {route.label}
+              </div>
+            );
+            return (
+              <div key={route.href}>
+                {isDisabled ? (
+                  <div className={tabClassName}>{tabContent}</div>
+                ) : (
+                  <Link href={route.href} className={tabClassName}>
+                    {tabContent}
+                  </Link>
                 )}
-              >
-                <div className="flex items-center flex-1">
-                  <route.icon
-                    className={cn(
-                      "h-[18px] w-[18px] mr-2 shrink-0",
-                      route.active
-                        ? "text-muted-foreground"
-                        : "text-muted-foreground group-hover:text-muted-foreground",
-                    )}
-                  />
-                  {route.label}
-                </div>
-              </Link>
-              {route.label === "Settings" && (
-                <div className="my-2 border-t border-border" />
-              )}
-            </div>
-          ))}
+                {route.label === "Settings" && (
+                  <div className="my-2 border-t border-border" />
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
 


### PR DESCRIPTION
This pull request updates the navigation component to improve user experience during loading states. The main change is that navigation tabs (except the currently active one) are now visually disabled and non-interactive when a loading state is active. This prevents users from navigating away while content is loading.

Navigation loading state improvements:

* Updated the navigation tab rendering logic in `frontend/components/navigation.tsx` to render non-active tabs as disabled (with reduced opacity and a not-allowed cursor) and as non-clickable divs instead of links when a loading state is present. This ensures users cannot navigate to other tabs while loading. [[1]](diffhunk://#diff-e983dc09cfcba4561feb1aa04728826db7c72d7e98b6b17eaafa2bf423ff91efL316-R327) [[2]](diffhunk://#diff-e983dc09cfcba4561feb1aa04728826db7c72d7e98b6b17eaafa2bf423ff91efR339-R354)

Closes #1216 