### PR TITLE
fix: added check for podman compose inside startup checks

### DIFF
--- a/src/tui/utils/startup_checks.py
+++ b/src/tui/utils/startup_checks.py
@@ -204,6 +204,7 @@ def compose_available() -> bool:
     # Try docker-compose (v1)
     if has_cmd("docker-compose"):
         return True
+    return False
 
 
 # =============================================================================


### PR DESCRIPTION
This pull request expands and improves support for Podman Compose in the startup checks utility. The main focus is to ensure environments using Podman have the necessary compose tooling available, whether as a built-in subcommand or a standalone binary, and to provide automated installation options for `podman-compose` across platforms.

The most important changes are:

**Compose availability checks:**

* The `compose_available()` function now checks for both Docker Compose and Podman Compose, including the built-in `podman compose` subcommand and the standalone `podman-compose` binary. This ensures broader compatibility with different container runtimes and installation methods. [[1]](diffhunk://#diff-bc4b81a0c70cccd0bfc86382a4c665814c706e5aa02470b47699cd03d38b5b64L194-R194) [[2]](diffhunk://#diff-bc4b81a0c70cccd0bfc86382a4c665814c706e5aa02470b47699cd03d38b5b64L205-R217)

**Podman Compose installation:**

* Added a new `install_podman_compose()` function that installs the standalone `podman-compose` binary if it is not present, supporting macOS (via Homebrew) and Linux/WSL (via pip3 or the system package manager). This function is robust to different environments and provides user prompts and error handling.

**Startup check flow improvements:**

* Updated the `run_startup_checks()` function to always attempt installing `podman-compose` when Podman is the selected runtime, regardless of whether the built-in compose subcommand is available. This helps ensure all required dependencies are present for OpenRAG to function reliably with Podman.