### PR TITLE
fix: Use 'username' claim for user_id in IBM JWT

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -126,7 +126,7 @@ async def _get_ibm_user(request: Request, required: bool) -> Optional["User"]:
             if not sub:
                 logger.warning("IBM JWT is missing required 'sub' claim; treating as unauthenticated")
             else:
-                user_id = claims.get("uid") or sub
+                user_id = claims.get("username", sub)
                 email = claims.get("username", sub)
                 name = claims.get("display_name", claims.get("username", sub))
 


### PR DESCRIPTION
Replace use of the 'uid' claim with the 'username' claim when deriving user_id from IBM JWTs, and align user_id selection with email/name extraction. The change uses claims.get('username', sub) as the fallback to the subject (sub), making user_id consistent with the email and display name fields. Note: this also subtly changes behavior when a username key exists but is empty (it will now be used rather than falling back to sub).