### PR TITLE
fix: add extra_hosts for hostname resolution in Langflow on Linux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,6 +128,8 @@ services:
     volumes:
       - ${OPENRAG_FLOWS_PATH:-./flows}:/app/flows:U,z
       - ${LANGFLOW_DATA_PATH:-./langflow-data}:/app/langflow-data:U,z
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     image: langflowai/openrag-langflow:${OPENRAG_VERSION:-latest}
     build:
       context: .


### PR DESCRIPTION
This PR adds `extra_hosts` for hostname resolution in Langflow on Linux.

Why:
- fixes hostname resolution issue in Linux environment

Notes:
- this fix is intended for Linux
- not tested on macOS or Windows

Tested on:
- Linux
- started the stack with Docker Compose
- verified Langflow works correctly

---

### Related Issues

- https://github.com/langflow-ai/openrag/issues/1267
- https://github.com/langflow-ai/openrag/issues/1297
