### PR TITLE
fix: added basic credentials to encryption keys

### DIFF
--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -113,7 +113,7 @@ class ConnectionManager:
         secret_keys = {
             "api_key", "hmac_secret_key", "secret_key", "client_secret",
             "aws_secret_access_key", "ibm_api_key", "access_token", "refresh_token",
-            "access_key", "hmac_access_key", "service_instance_id"
+            "access_key", "hmac_access_key", "service_instance_id", "basic_credentials"
         }
         
         data = {"connections": []}


### PR DESCRIPTION
This pull request makes a small update to the list of secret keys in the `save_connections` method of `connection_manager.py`, adding support for the `basic_credentials` key. This ensures that any credentials stored under this key are handled securely.

* Added `"basic_credentials"` to the set of secret keys in the `save_connections` method to ensure it is treated as sensitive information.