### PR TITLE
fix: add IBM user to the session

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -254,7 +254,7 @@ async def get_current_user(
     if IBM_AUTH_ENABLED:
         logger.debug("[IBM Auth] IBM auth mode enabled, getting current user")
         user = await _get_ibm_user(request, required=True)
-        if user and user.user_id not in session_manager.users:
+        if user and user.user_id and user.user_id not in session_manager.users:
             session_manager.users[user.user_id] = user
         return user
 


### PR DESCRIPTION
This pull request updates the user authentication flow to ensure that users authenticated via IBM AMS cookie are properly tracked in the `session_manager`. Now, after a user is authenticated with IBM AMS, the user is added to the `session_manager.users` dictionary if they are not already present.

**Session management improvements:**

* After authenticating a user with IBM AMS cookie in `get_current_user`, the user is added to `session_manager.users` if not already tracked.
* Similarly, in `get_optional_user`, the user is added to `session_manager.users` if they have a `user_id` and are not already present.