### PR TITLE
fix(security): Containerized Frontend application is running as root

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,17 +1,21 @@
 FROM node:20.20.0-slim
 
-# Set working directory
+# Set working directory and ensure it is owned by the non-root node user
 WORKDIR /app
+RUN chown node:node /app
+
+# Switch to non-root user for all subsequent steps
+USER node
 
 # Copy frontend dependencies
-COPY frontend/package*.json ./
+COPY --chown=node:node frontend/package*.json ./
 RUN npm install
 
 # Copy frontend source
-COPY frontend/ ./
+COPY --chown=node:node frontend/ ./
 
 # Build frontend
-RUN npm run build 
+RUN npm run build
 
 # Expose frontend port
 EXPOSE 3000


### PR DESCRIPTION
### Issue

- #1320

### Summary

- Fixed the frontend Docker container running as root by switching to the built-in non-root `node` user for all build and runtime steps.

### Security: Run frontend container as non-root user

- Added `chown node:node /app` after `WORKDIR` so the working directory is owned by the non-root user before the user switch.
- Added `USER node` directive to switch to the non-root `node` user for all subsequent Dockerfile instructions.
- Updated `COPY` instructions to use `--chown=node:node` so copied files are owned by the `node` user rather than root.
- Removed trailing whitespace from `npm run build` line.
- Added missing newline at end of file.