### PR TITLE
refactor: fix saas styles for the chunks page

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -59,6 +59,9 @@
     --component-icon: #d8598a;
     --flow-icon: #2f67d0;
 
+    --badge: 0 0% 0%; /* #000000 */
+    --badge-foreground: 0 0% 100%; /* #FFFFFF */
+
     --radius: 0.5rem;
 
     --sidebar-background: 0 0% 98%;
@@ -142,6 +145,9 @@
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
 
+    --badge: 0 0% 25%; /* #404040 */
+    --badge-foreground: 0 0% 100%; /* #FFFFFF */
+
     /* Failure Colors */
     --failure-soft: #46080933;
     --failure-pill: #fb2c361a;
@@ -167,7 +173,7 @@
     --secondary-foreground: 0 0% 15%;
     --secondary-hover: 0 0% 90%; /* IBM Gray 20 #e0e0e0 */
     --muted: 0 0% 90%; /* IBM Gray 20 #e0e0e0 */
-    --muted-foreground: 0 0% 78%; /* IBM Gray 30 #C6C6C6 - Secondary text IBM */
+    --muted-foreground: 0 0% 32%; /* IBM Gray 70 #525252 - Secondary text IBM light */
     --accent: 0 0% 90%;
     --accent-foreground: 0 0% 15%;
     --border: 240 5% 96%; /* same as --muted from :root (240 5% 96%) */
@@ -228,6 +234,9 @@
     --text-text-01: 0 0% 9%;
     --link-primary: 217 100% 45%;
     --button-tertiary: 217 100% 45%;
+
+    --badge: 0 0% 22.4%; /* #393939 */
+    --badge-foreground: 0 0% 95.7%; /* #F4F4F4 */
   }
 
   /* IBM Dark */
@@ -246,7 +255,7 @@
     --secondary-foreground: 0 0% 97%;
     --secondary-hover: 0 0% 18%; /* IBM Gray 80 #393939 */
     --muted: 0 0% 18%; /* IBM Gray 80 */
-    --muted-foreground: 0 0% 32%; /* IBM Gray 70 #525252 - Secondary text IBM */
+    --muted-foreground: 0 0% 78%; /* IBM Gray 30 #C6C6C6 - Secondary text IBM dark */
     --accent: 0 0% 18%;
     --accent-foreground: 0 0% 97%;
     --border: 0 0% 22.4%; /* IBM Gray 80 #393939 - Ui-border 3 */
@@ -306,6 +315,9 @@
     --text-text-01: 0 0% 95.7%;
     --link-primary: 217 100% 74%;
     --button-tertiary: 217 100% 74%;
+
+    --badge: 0 0% 32%; /* #525252 */
+    --badge-foreground: 0 0% 95.7%; /* #F4F4F4 */
   }
 
   /* IBM Settings: Override muted-foreground for settings page */
@@ -359,7 +371,7 @@
     border: none;
     border-radius: 0;
     border-bottom: 2px solid hsl(var(--input));
-    background-color: hsl(var(--card));
+    background-color: hsl(var(--muted));
   }
 
   [data-theme="ibm"] .primary-input:hover {

--- a/frontend/app/knowledge/chunks/page.tsx
+++ b/frontend/app/knowledge/chunks/page.tsx
@@ -9,6 +9,7 @@ import { KnowledgeSearchInput } from "@/components/knowledge-search-input";
 // import { Label } from "@/components/ui/label";
 // import { Checkbox } from "@/components/ui/checkbox";
 import { ProtectedRoute } from "@/components/protected-route";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Tooltip,
@@ -203,9 +204,9 @@ function ChunksPageContent() {
                       <span className="text-sm font-bold">
                         Chunk {chunk.index}
                       </span>
-                      <span className="bg-background p-1 rounded text-xs text-muted-foreground/70">
+                      <Badge variant="secondary">
                         {chunk.text.length} chars
-                      </span>
+                      </Badge>
                       <div className="py-1">
                         <Button
                           onClick={() => handleCopy(chunk.text, index)}
@@ -221,9 +222,9 @@ function ChunksPageContent() {
                       </div>
                     </div>
 
-                    <span className="bg-background p-1 rounded text-xs text-muted-foreground/70">
+                    <Badge variant="secondary">
                       {chunk.score.toFixed(2)} score
-                    </span>
+                    </Badge>
 
                     {/* TODO: Update to use active toggle */}
                     {/* <span className="px-2 py-1 text-green-500">

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -11,7 +11,7 @@ const badgeVariants = cva(
         default:
           "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "border-transparent bg-badge text-badge-foreground hover:bg-badge/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -165,6 +165,10 @@ const config = {
         "component-icon": "var(--component-icon)",
         "flow-icon": "var(--flow-icon)",
         "placeholder-foreground": "hsl(var(--placeholder-foreground))",
+        badge: {
+          DEFAULT: "hsl(var(--badge))",
+          foreground: "hsl(var(--badge-foreground))",
+        },
         warning: {
           DEFAULT: "hsl(var(--warning))",
           foreground: "hsl(var(--warning-foreground))",


### PR DESCRIPTION
Before:
<img width="1488" height="677" alt="Screenshot 2026-04-02 at 3 20 05 PM" src="https://github.com/user-attachments/assets/d9fb32a3-8c44-4f43-8539-478104c74d39" />
<img width="1380" height="743" alt="Screenshot 2026-04-02 at 3 20 11 PM" src="https://github.com/user-attachments/assets/b897f67e-e420-4752-a1fe-951f4e487143" />


After
<img width="1465" height="860" alt="Screenshot 2026-04-02 at 3 19 35 PM" src="https://github.com/user-attachments/assets/5ee3b244-78fd-4554-b410-5358b83797a7" />
<img width="1472" height="758" alt="Screenshot 2026-04-02 at 3 19 26 PM" src="https://github.com/user-attachments/assets/00ff0ffd-2a63-4aa4-8848-477b1149d2e1" />

The badge is changed in OSS as well seeking more design alignment