### PR TITLE
feat: SaaS handling of MCP/SDK

### DIFF
--- a/sdks/mcp/src/openrag_mcp/config.py
+++ b/sdks/mcp/src/openrag_mcp/config.py
@@ -43,9 +43,18 @@ class Config:
     def __init__(self):
         self.openrag_url = os.environ.get("OPENRAG_URL", "http://localhost:3000")
         self.api_key = os.environ.get("OPENRAG_API_KEY")
-        ibm_auth_enabled = _parse_bool("IBM_AUTH_ENABLED", False)
 
-        if not self.api_key and not ibm_auth_enabled:
+        # IBM auth mode: user provides IBM_USERNAME + IBM_API_KEY instead of OPENRAG_API_KEY.
+        # The MCP forwards these as headers on every SDK request to OpenRAG.
+        ibm_username = os.environ.get("IBM_USERNAME")
+        ibm_api_key = os.environ.get("IBM_API_KEY")
+        self.ibm_extra_headers: dict[str, str] = {}
+        if ibm_username:
+            self.ibm_extra_headers["X-Username"] = ibm_username
+        if ibm_api_key:
+            self.ibm_extra_headers["X-Api-Key"] = ibm_api_key
+
+        if not self.api_key and not self.ibm_extra_headers:
             raise ValueError(
                 "OPENRAG_API_KEY environment variable is required. "
                 "Create an API key in OpenRAG Settings > API Keys."
@@ -86,7 +95,10 @@ def get_openrag_client() -> OpenRAGClient:
     global _openrag_client
     if _openrag_client is None:
         config = get_config()
-        _openrag_client = OpenRAGClient(api_key=config.api_key)
+        _openrag_client = OpenRAGClient(
+            api_key=config.api_key,
+            extra_headers=config.ibm_extra_headers or None,
+        )
     return _openrag_client
 
 

--- a/sdks/mcp/src/openrag_mcp/config.py
+++ b/sdks/mcp/src/openrag_mcp/config.py
@@ -43,8 +43,9 @@ class Config:
     def __init__(self):
         self.openrag_url = os.environ.get("OPENRAG_URL", "http://localhost:3000")
         self.api_key = os.environ.get("OPENRAG_API_KEY")
+        ibm_auth_enabled = _parse_bool("IBM_AUTH_ENABLED", False)
 
-        if not self.api_key:
+        if not self.api_key and not ibm_auth_enabled:
             raise ValueError(
                 "OPENRAG_API_KEY environment variable is required. "
                 "Create an API key in OpenRAG Settings > API Keys."
@@ -62,10 +63,10 @@ class Config:
     @property
     def headers(self) -> dict[str, str]:
         """Get HTTP headers for API requests."""
-        return {
-            "X-API-Key": self.api_key,
-            "Content-Type": "application/json",
-        }
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["X-API-Key"] = self.api_key
+        return headers
 
 
 _config: Config | None = None
@@ -84,8 +85,8 @@ def get_openrag_client() -> OpenRAGClient:
     """Get singleton OpenRAGClient instance."""
     global _openrag_client
     if _openrag_client is None:
-        # OpenRAGClient reads OPENRAG_API_KEY and OPENRAG_URL from env
-        _openrag_client = OpenRAGClient()
+        config = get_config()
+        _openrag_client = OpenRAGClient(api_key=config.api_key)
     return _openrag_client
 
 

--- a/sdks/python/openrag_sdk/client.py
+++ b/sdks/python/openrag_sdk/client.py
@@ -116,6 +116,7 @@ class OpenRAGClient:
         self,
         api_key: str | None = None,
         *,
+        extra_headers: dict[str, str] | None = None,
         base_url: str | None = None,
         timeout: float = 30.0,
         http_client: httpx.AsyncClient | None = None,
@@ -126,12 +127,15 @@ class OpenRAGClient:
         Args:
             api_key: API key for authentication. Falls back to OPENRAG_API_KEY env var.
                 Optional when using IBM auth — the proxy layer handles authentication.
+            extra_headers: Additional headers forwarded on every request. Used in IBM
+                auth mode to pass X-Username and X-Api-Key injected by the proxy.
             base_url: Base URL for the API. Falls back to OPENRAG_URL env var, then default.
             timeout: Request timeout in seconds (default 30).
             http_client: Optional custom httpx.AsyncClient instance.
         """
         # Resolve API key from argument or environment
         self._api_key = api_key or os.environ.get("OPENRAG_API_KEY")
+        self._extra_headers: dict[str, str] = extra_headers or {}
 
         # Resolve base URL from argument or environment
         self._base_url = (
@@ -160,7 +164,7 @@ class OpenRAGClient:
     @property
     def _headers(self) -> dict[str, str]:
         """Get request headers with authentication."""
-        headers: dict[str, str] = {"Content-Type": "application/json"}
+        headers: dict[str, str] = {"Content-Type": "application/json", **self._extra_headers}
         if self._api_key:
             headers["X-API-Key"] = self._api_key
         return headers

--- a/sdks/python/openrag_sdk/client.py
+++ b/sdks/python/openrag_sdk/client.py
@@ -125,16 +125,13 @@ class OpenRAGClient:
 
         Args:
             api_key: API key for authentication. Falls back to OPENRAG_API_KEY env var.
+                Optional when using IBM auth — the proxy layer handles authentication.
             base_url: Base URL for the API. Falls back to OPENRAG_URL env var, then default.
             timeout: Request timeout in seconds (default 30).
             http_client: Optional custom httpx.AsyncClient instance.
         """
         # Resolve API key from argument or environment
         self._api_key = api_key or os.environ.get("OPENRAG_API_KEY")
-        if not self._api_key:
-            raise AuthenticationError(
-                "API key is required. Set OPENRAG_API_KEY environment variable or pass api_key argument."
-            )
 
         # Resolve base URL from argument or environment
         self._base_url = (
@@ -163,10 +160,10 @@ class OpenRAGClient:
     @property
     def _headers(self) -> dict[str, str]:
         """Get request headers with authentication."""
-        return {
-            "X-API-Key": self._api_key,
-            "Content-Type": "application/json",
-        }
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["X-API-Key"] = self._api_key
+        return headers
 
     async def _request(
         self,

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -335,15 +335,54 @@ async def get_api_key_user_async(
     session_manager=Depends(get_session_manager),
 ) -> User:
     """
-    Async dependency: require API key authentication.
+    Async dependency: require API key or IBM authentication.
 
     Accepts:
       - X-API-Key: orag_... header
       - Authorization: Bearer orag_... header
+      - X-IBM-LH-Credentials + Authorization: Bearer <jwt> (when IBM_AUTH_ENABLED)
 
-    Raises HTTP 401 if no valid key is provided.
+    Raises HTTP 401 if no valid credentials are provided.
     """
-    # Extract key from headers
+    from config.settings import IBM_AUTH_ENABLED, IBM_CREDENTIALS_HEADER
+
+    # IBM auth path: X-IBM-LH-Credentials + Authorization: Bearer <jwt>
+    if IBM_AUTH_ENABLED:
+        lh_credentials = request.headers.get(IBM_CREDENTIALS_HEADER, "")
+        auth_header = request.headers.get("Authorization", "")
+        if lh_credentials and auth_header.startswith("Bearer "):
+            import auth.ibm_auth as ibm_auth
+            from auth.ibm_auth import extract_ibm_credentials
+
+            ibm_token = auth_header[7:]
+            claims = ibm_auth.decode_ibm_jwt(ibm_token)
+
+            user_id = None
+            email = None
+            name = None
+            if claims:
+                sub = claims.get("sub")
+                if sub:
+                    user_id = claims.get("username", sub)
+                    email = claims.get("username", sub)
+                    name = claims.get("display_name", claims.get("username", sub))
+
+            opensearch_username, _ = extract_ibm_credentials(lh_credentials)
+
+            user = User(
+                user_id=user_id,
+                email=email,
+                name=name,
+                picture=None,
+                provider="ibm_ams",
+                jwt_token=f"Basic {lh_credentials}",
+                opensearch_username=opensearch_username,
+                opensearch_credentials=lh_credentials,
+            )
+            request.state.user = user
+            return user
+
+    # API key path
     api_key = request.headers.get("X-API-Key")
     if not api_key or not api_key.startswith("orag_"):
         auth_header = request.headers.get("Authorization", "")


### PR DESCRIPTION
This pull request introduces support for IBM authentication as an alternative to API key authentication throughout the OpenRAG codebase. It updates configuration handling, client instantiation, and authentication logic to enable seamless use of IBM credentials when the `IBM_AUTH_ENABLED` environment variable is set. The changes ensure that API key requirements are relaxed when IBM authentication is available, and headers are constructed dynamically based on the authentication method in use.

**Authentication logic updates:**

* The authentication dependency in `src/dependencies.py` now accepts IBM authentication via the `X-IBM-LH-Credentials` and `Authorization: Bearer <jwt>` headers when `IBM_AUTH_ENABLED` is set, constructing the `User` object accordingly.

**Configuration and client improvements:**

* The `Config` class in `sdks/mcp/src/openrag_mcp/config.py` no longer requires an API key if IBM authentication is enabled, and dynamically builds headers to include the API key only when present. [[1]](diffhunk://#diff-4ab415900c943ee5b416ddbb3f1410e29390a15e18b4dcc3fd969c404d3e6b22R46-R48) [[2]](diffhunk://#diff-4ab415900c943ee5b416ddbb3f1410e29390a15e18b4dcc3fd969c404d3e6b22L65-R69)
* The `get_openrag_client` function now instantiates the `OpenRAGClient` with the API key from the config, supporting cases where the API key may be absent due to IBM authentication.
* The `OpenRAGClient` in `sdks/python/openrag_sdk/client.py` no longer raises an error if the API key is missing, and its headers property only adds the `X-API-Key` header when an API key is available, supporting IBM authentication scenarios. [[1]](diffhunk://#diff-5f4d67278e841b52d68d6ee16092dee4df7117969b675b5dfb163c527b87654aR128-L137) [[2]](diffhunk://#diff-5f4d67278e841b52d68d6ee16092dee4df7117969b675b5dfb163c527b87654aL166-R166)