### PR TITLE
fix: change factory-reset functions to delete named volume for opensearch-data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,10 +54,6 @@ NUDGES_FLOW_ID=ebc01d31-1976-46ce-a385-b0240327226c
 # The password must contain at least 8 characters, and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.
 OPENSEARCH_PASSWORD=
 
-# Path to persist OpenSearch data (indices, documents, cluster state)
-# Default: ./opensearch-data
-OPENSEARCH_DATA_PATH=./opensearch-data
-
 # Path to persist Langflow database and state (flows, credentials, settings)
 # Without this volume, flow edits will be lost on container restart
 # Default: ./langflow-data

--- a/Makefile
+++ b/Makefile
@@ -506,7 +506,6 @@ factory-reset: ## Complete reset (stop, remove volumes, clear data, remove image
 	echo "$(YELLOW)This will:$(NC)"; \
 	echo "  - Stop all containers"; \
 	echo "  - Remove all volumes"; \
-	echo "  - Delete opensearch-data directory"; \
 	echo "  - Delete langflow-data directory"; \
 	echo "  - Delete config directory"; \
 	echo "  - Delete JWT keys (private_key.pem, public_key.pem)"; \
@@ -524,13 +523,6 @@ factory-reset: ## Complete reset (stop, remove volumes, clear data, remove image
 	echo "$(YELLOW)Stopping all services and removing volumes...$(NC)"; \
 	$(COMPOSE_CMD) down -v --remove-orphans || true; \
 	echo "$(YELLOW)Removing local data directories...$(NC)"; \
-	if [ -d "opensearch-data" ]; then \
-		echo "Removing opensearch-data..."; \
-		uv run python scripts/clear_opensearch_data.py 2>/dev/null || \
-		$(CONTAINER_RUNTIME) run --rm -v "$$(pwd)/opensearch-data:/data" alpine sh -c "rm -rf /data/*" 2>/dev/null || \
-		rm -rf opensearch-data/* 2>/dev/null || true; \
-		echo "$(PURPLE)opensearch-data removed$(NC)"; \
-	fi; \
 	if [ -d "langflow-data" ]; then \
 		echo "Removing langflow-data..."; \
 		rm -rf langflow-data; \
@@ -1014,10 +1006,10 @@ db-reset: ## Reset OpenSearch indices
 	curl -X DELETE "http://localhost:9200/knowledge_filters" -u admin:$${OPENSEARCH_PASSWORD} || true
 	@echo "$(PURPLE)Indices reset. Restart backend to recreate.$(NC)"
 
-clear-os-data: ## Clear OpenSearch data directory
-	@echo "$(YELLOW)Clearing OpenSearch data directory...$(NC)"
+clear-os-data: ## Clear OpenSearch data volume
+	@echo "$(YELLOW)Clearing OpenSearch data volume...$(NC)"
 	@uv run python scripts/clear_opensearch_data.py
-	@echo "$(PURPLE)OpenSearch data cleared.$(NC)"
+	@echo "$(PURPLE)OpenSearch data volume cleared.$(NC)"
 
 ######################
 # FLOW MANAGEMENT

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -137,7 +137,6 @@ Configure OpenSearch database authentication.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OPENSEARCH_DATA_PATH` | `./opensearch-data` | The path where OpenRAG creates your OpenSearch index data. This persists through updates. |
 | `OPENSEARCH_PASSWORD` | Not set | Required. OpenSearch administrator password. Must adhere to the [OpenSearch password complexity requirements](https://docs.opensearch.org/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password). You must set this directly in the `.env` or in the terminal's [**Reconfigure**](/install-uvx#setup) option. |
 | `OPENSEARCH_INDEX_NAME` | `documents` | The name of the [OpenSearch index](/knowledge#index). |
 | `OPENSEARCH_HOST` | `localhost` | OpenSearch service host. |

--- a/frontend/.env.test.example
+++ b/frontend/.env.test.example
@@ -6,7 +6,6 @@ INGEST_SAMPLE_DATA=true
 OPENSEARCH_PASSWORD=
 
 # Paths
-OPENSEARCH_DATA_PATH=./opensearch-data
 LANGFLOW_DATA_PATH=./langflow-data
 OPENSEARCH_INDEX_NAME=documents
 

--- a/scripts/clear_opensearch_data.py
+++ b/scripts/clear_opensearch_data.py
@@ -12,29 +12,20 @@ from src.tui.managers.container_manager import ContainerManager
 
 
 async def main():
-    """Clear OpenSearch data directory."""
+    """Clear OpenSearch data volume."""
     cm = ContainerManager()
 
-    # Get opensearch data path from env config (same as container_manager uses)
-    from src.tui.managers.env_manager import EnvManager
-    env_manager = EnvManager()
-    env_manager.load_existing_env()
-    opensearch_data_path = Path(
-        env_manager.config.opensearch_data_path.replace("$HOME", str(Path.home()))
-    ).expanduser()
+    if not cm.is_available():
+        print("Error: No container runtime available")
+        return 1
 
-    if not opensearch_data_path.exists():
-        print(f"opensearch-data directory does not exist at {opensearch_data_path}")
-        return 0
-    
-    print("Clearing OpenSearch data directory...")
-    
+    print("Clearing OpenSearch data volume...")
+
     async for success, message in cm.clear_opensearch_data_volume():
         print(message)
         if not success and "failed" in message.lower():
             return 1
-    
-    print("✅ OpenSearch data cleared successfully")
+
     return 0
 
 

--- a/src/tui/config_fields.py
+++ b/src/tui/config_fields.py
@@ -67,12 +67,6 @@ CONFIG_SECTIONS: list[ConfigSection] = [
             helper_text="Override for remote OpenSearch instances (default: 9200)",
         ),
         ConfigField(
-            "opensearch_data_path", "OPENSEARCH_DATA_PATH", "Data Path",
-            placeholder="~/.openrag/data/opensearch-data",
-            default="$HOME/.openrag/data/opensearch-data",
-            helper_text="Directory to persist OpenSearch indices across upgrades",
-        ),
-        ConfigField(
             "opensearch_index_name", "OPENSEARCH_INDEX_NAME", "Index Name",
             placeholder="documents", default="documents",
             helper_text="Name of the index to use in OpenSearch",

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -562,7 +562,7 @@ def migrate_legacy_data_directories():
     """Migrate data from CWD-based directories to ~/.openrag/.
 
     This is a one-time migration for users upgrading from the old layout.
-    Migrates: documents, flows, keys, config, opensearch-data, langflow-data
+    Migrates: documents, flows, keys, config, langflow-data
 
     Prompts user for confirmation before migrating. If user declines,
     exits with a message to downgrade to v1.52 or earlier.
@@ -584,7 +584,8 @@ def migrate_legacy_data_directories():
         (cwd / "flows", target_base / "flows", "flows"),
         (cwd / "keys", target_base / "keys", "keys"),
         (cwd / "config", target_base / "config", "config"),
-        (cwd / "opensearch-data", target_base / "data" / "opensearch-data", "OpenSearch data"),
+        # opensearch-data intentionally omitted: OpenSearch now uses a Docker named
+        # volume; old index data is not portable and must be re-ingested.
         (cwd / "langflow-data", target_base / "data" / "langflow-data", "Langflow data"),
     ]
 
@@ -753,7 +754,6 @@ def setup_host_directories():
     - ~/.openrag/keys/ (for JWT keys)
     - ~/.openrag/config/ (for configuration)
     - ~/.openrag/data/ (for backend data: conversations, OAuth tokens, etc.)
-    - ~/.openrag/data/opensearch-data/ (for OpenSearch index)
     - LANGFLOW_DATA_PATH (for Langflow database and state)
     """
     base_dir = Path.home() / ".openrag"
@@ -763,7 +763,6 @@ def setup_host_directories():
         base_dir / "keys",
         base_dir / "config",
         base_dir / "data",
-        base_dir / "data" / "opensearch-data",
     ]
 
     for directory in directories:

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -608,7 +608,6 @@ def migrate_legacy_data_directories():
             env_manager.config.openrag_flows_path = f"{home}/.openrag/flows"
             env_manager.config.openrag_config_path = f"{home}/.openrag/config"
             env_manager.config.openrag_data_path = f"{home}/.openrag/data"
-            env_manager.config.opensearch_data_path = f"{home}/.openrag/data/opensearch-data"
             env_manager.config.langflow_data_path = f"{home}/.openrag/data/langflow-data"
             env_manager.save_env_file()
             logger.info("Updated .env file with centralized paths")
@@ -688,7 +687,6 @@ def migrate_legacy_data_directories():
         env_manager.config.openrag_flows_path = f"{home}/.openrag/flows"
         env_manager.config.openrag_config_path = f"{home}/.openrag/config"
         env_manager.config.openrag_data_path = f"{home}/.openrag/data"
-        env_manager.config.opensearch_data_path = f"{home}/.openrag/data/opensearch-data"
         env_manager.config.langflow_data_path = f"{home}/.openrag/data/langflow-data"
         env_manager.save_env_file()
         print("  Updated .env with centralized paths")

--- a/src/tui/managers/container_manager.py
+++ b/src/tui/managers/container_manager.py
@@ -1278,23 +1278,41 @@ class ContainerManager:
 
         yield False, "Clearing OpenSearch data volume..."
 
-        # Get opensearch data path from env config
-        from .env_manager import EnvManager
-        env_manager = EnvManager()
-        env_manager.load_existing_env()
-        opensearch_data_path = Path(env_manager.config.opensearch_data_path.replace("$HOME", str(Path.home()))).expanduser().absolute()
+        # The volume name is 'opensearch-data' as defined in docker-compose.yml.
+        # Docker Compose usually prefixes it with the project name (defaulting to the directory name).
+        volume_name = "opensearch-data"
+        
+        # Try both the plain name and common prefixed versions
+        possible_names = [volume_name]
+        
+        # Current folder name is a common prefix
+        project_name = Path.cwd().name.lower().replace("-", "").replace("_", "")
+        possible_names.append(f"{project_name}_{volume_name}")
+        
+        # Another common prefix pattern
+        project_name_simple = Path.cwd().name.lower()
+        possible_names.append(f"{project_name_simple}_{volume_name}")
 
-        if not opensearch_data_path.exists():
-            yield True, "OpenSearch data directory does not exist, skipping"
-            return
+        last_error = "Unknown error"
+        for name in possible_names:
+            # Use alpine with root to clear container-owned files
+            cmd = [
+                "run", "--rm",
+                "-v", f"{name}:/work:Z",
+                "alpine",
+                "sh", "-c",
+                "rm -rf /work/* /work/.[!.]* 2>/dev/null; echo done"
+            ]
+            
+            success, stdout, stderr = await self._run_runtime_command(cmd)
+            if success and "done" in stdout:
+                yield True, f"OpenSearch data volume '{name}' cleared successfully"
+                return
 
-        # Use alpine with root to clear container-owned files
-        success, msg = await self.clear_directory_with_container(opensearch_data_path)
+            if stderr:
+                last_error = stderr.strip()
 
-        if success:
-            yield True, "OpenSearch data cleared successfully"
-        else:
-            yield False, f"Failed to clear OpenSearch data: {msg}"
+        yield False, f"Failed to clear OpenSearch data volume: {last_error}"
 
     async def reset_services(self) -> AsyncIterator[tuple[bool, str]]:
         """Reset all services (stop, remove containers/volumes, clear data) and yield progress updates."""

--- a/src/tui/managers/container_manager.py
+++ b/src/tui/managers/container_manager.py
@@ -1282,37 +1282,33 @@ class ContainerManager:
         # Docker Compose usually prefixes it with the project name (defaulting to the directory name).
         volume_name = "opensearch-data"
         
-        # Try both the plain name and common prefixed versions
-        possible_names = [volume_name]
-        
-        # Current folder name is a common prefix
-        project_name = Path.cwd().name.lower().replace("-", "").replace("_", "")
-        possible_names.append(f"{project_name}_{volume_name}")
-        
-        # Another common prefix pattern
-        project_name_simple = Path.cwd().name.lower()
-        possible_names.append(f"{project_name_simple}_{volume_name}")
+        possible_names = list(dict.fromkeys([
+            volume_name,
+            f"{Path.cwd().name.lower()}_{volume_name}",              # e.g. openrag_opensearch-data
+            f"{Path.cwd().name.lower().replace('-', '')}_{volume_name}",  # e.g. openrag_opensearch-data (dashes stripped)
+        ]))
 
-        last_error = "Unknown error"
-        for name in possible_names:
-            # Use alpine with root to clear container-owned files
-            cmd = [
-                "run", "--rm",
-                "-v", f"{name}:/work:Z",
-                "alpine",
-                "sh", "-c",
-                "rm -rf /work/* /work/.[!.]* 2>/dev/null; echo done"
-            ]
-            
-            success, stdout, stderr = await self._run_runtime_command(cmd)
-            if success and "done" in stdout:
-                yield True, f"OpenSearch data volume '{name}' cleared successfully"
-                return
+        # List volumes and find the correct one
+        list_success, stdout, _ = await self._run_runtime_command(["volume", "ls", "--format", "{{.Name}}"])
+        if not list_success:
+            yield False, "Could not list Docker volumes"
+            return
 
-            if stderr:
-                last_error = stderr.strip()
+        existing_volumes = set(stdout.splitlines())
+        found_name = next((n for n in possible_names if n in existing_volumes), None)
 
-        yield False, f"Failed to clear OpenSearch data volume: {last_error}"
+        if found_name is None:
+            yield True, "OpenSearch data volume not found — already removed or never created"
+            return
+
+        # Only clear the volume we know exists
+        cmd = ["run", "--rm", "-v", f"{found_name}:/work:Z", "alpine", "sh", "-c",
+            "rm -rf /work/* /work/.[!.]* 2>/dev/null; echo done"]
+        success, stdout, stderr = await self._run_runtime_command(cmd)
+        if success and "done" in stdout:
+            yield True, f"OpenSearch data volume '{found_name}' cleared successfully"
+        else:
+            yield False, f"Failed to clear OpenSearch data volume '{found_name}': {stderr}"
 
     async def reset_services(self) -> AsyncIterator[tuple[bool, str]]:
         """Reset all services (stop, remove containers/volumes, clear data) and yield progress updates."""

--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -94,7 +94,6 @@ class EnvConfig:
     openrag_flows_path: str = "$HOME/.openrag/flows"
     openrag_config_path: str = "$HOME/.openrag/config"
     openrag_data_path: str = "$HOME/.openrag/data"  # Backend data (conversations, tokens, etc.)
-    opensearch_data_path: str = "$HOME/.openrag/data/opensearch-data"
     langflow_data_path: str = "$HOME/.openrag/data/langflow-data"
     openrag_tui_config_path_legacy: str = "$HOME/.openrag/tui/config"
 
@@ -212,7 +211,6 @@ class EnvManager:
             "OPENRAG_FLOWS_PATH": "openrag_flows_path",
             "OPENRAG_CONFIG_PATH": "openrag_config_path",
             "OPENRAG_DATA_PATH": "openrag_data_path",
-            "OPENSEARCH_DATA_PATH": "opensearch_data_path",
             "LANGFLOW_DATA_PATH": "langflow_data_path",
             "LANGFLOW_AUTO_LOGIN": "langflow_auto_login",
             "LANGFLOW_NEW_USER_IS_ACTIVE": "langflow_new_user_is_active",
@@ -492,9 +490,6 @@ class EnvManager:
                     f"OPENRAG_DATA_PATH={self._quote_env_value(expand_path(self.config.openrag_data_path))}\n"
                 )
                 f.write(
-                    f"OPENSEARCH_DATA_PATH={self._quote_env_value(expand_path(self.config.opensearch_data_path))}\n"
-                )
-                f.write(
                     f"LANGFLOW_DATA_PATH={self._quote_env_value(expand_path(self.config.langflow_data_path))}\n"
                 )
                 # Set OPENRAG_VERSION to TUI version
@@ -762,11 +757,11 @@ class EnvManager:
                     else:
                         new_lines.append(line)
 
-                # If not found, add it after OPENSEARCH_DATA_PATH or at the end
+                # If not found, add it after LANGFLOW_DATA_PATH or at the end
                 if not updated:
                     insert_pos = len(new_lines)
                     for i, line in enumerate(new_lines):
-                        if "OPENSEARCH_DATA_PATH" in line:
+                        if "LANGFLOW_DATA_PATH" in line:
                             insert_pos = i + 1
                             break
                     new_lines.insert(insert_pos, f"OPENRAG_VERSION={self._quote_env_value(current_version)}")

--- a/src/tui/screens/config.py
+++ b/src/tui/screens/config.py
@@ -201,7 +201,6 @@ class ConfigScreen(Screen):
     # Fields that need custom rendering beyond the standard pattern
     SPECIAL_FIELDS = {
         "opensearch_password",
-        "opensearch_data_path",
         "langflow_superuser_password",
         "langflow_superuser",
         "langflow_data_path",
@@ -287,25 +286,6 @@ class ConfigScreen(Screen):
             yield input_widget
             self.inputs[field.name] = input_widget
             yield Button("👁", id=f"toggle-{field.name}", variant="default")
-        yield Static(" ")
-
-    def _render_opensearch_data_path(self, field: ConfigField) -> ComposeResult:
-        """OpenSearch data path with file picker."""
-        yield Label(field.label)
-        yield Static(field.helper_text, classes="helper-text")
-        current_value = getattr(self.env_manager.config, field.name, field.default)
-        input_widget = Input(
-            placeholder=field.placeholder,
-            value=current_value,
-            id=f"input-{field.name}",
-        )
-        yield input_widget
-        yield Horizontal(
-            Button("Pick…", id="pick-opensearch-data-btn"),
-            id="opensearch-data-path-actions",
-            classes="controls-row",
-        )
-        self.inputs[field.name] = input_widget
         yield Static(" ")
 
     def _render_langflow_data_path(self, field: ConfigField) -> ComposeResult:
@@ -475,8 +455,6 @@ class ConfigScreen(Screen):
             self.action_back()
         elif event.button.id == "pick-docs-btn":
             self.action_pick_documents_path()
-        elif event.button.id == "pick-opensearch-data-btn":
-            self.action_pick_opensearch_data_path()
         elif event.button.id == "pick-langflow-data-btn":
             self.action_pick_langflow_data_path()
         elif event.button.id and event.button.id.startswith("toggle-"):
@@ -620,62 +598,6 @@ class ConfigScreen(Screen):
             self.app.push_screen(picker, _append_path)  # type: ignore[arg-type]
         except TypeError:
             self._docs_pick_callback = _append_path  # type: ignore[attr-defined]
-            self.app.push_screen(picker)
-
-    def action_pick_opensearch_data_path(self) -> None:
-        """Open textual-fspicker to select OpenSearch data directory."""
-        try:
-            import importlib
-
-            fsp = importlib.import_module("textual_fspicker")
-        except Exception:
-            self.notify("textual-fspicker not available", severity="warning")
-            return
-
-        # Determine starting path from current input if possible
-        input_widget = self.inputs.get("opensearch_data_path")
-        start = Path.home()
-        if input_widget and input_widget.value:
-            path_str = input_widget.value.strip()
-            if path_str:
-                candidate = Path(path_str).expanduser()
-                # If path doesn't exist, use parent or fallback to home
-                if candidate.exists():
-                    start = candidate
-                elif candidate.parent.exists():
-                    start = candidate.parent
-
-        # Prefer SelectDirectory for directories; fallback to FileOpen
-        PickerClass = getattr(fsp, "SelectDirectory", None) or getattr(
-            fsp, "FileOpen", None
-        )
-        if PickerClass is None:
-            self.notify(
-                "No compatible picker found in textual-fspicker", severity="warning"
-            )
-            return
-        try:
-            picker = PickerClass(location=start)
-        except Exception:
-            try:
-                picker = PickerClass(start)
-            except Exception:
-                self.notify("Could not initialize textual-fspicker", severity="warning")
-                return
-
-        def _set_path(result) -> None:
-            if not result:
-                return
-            path_str = str(result)
-            if input_widget is None:
-                return
-            input_widget.value = path_str
-
-        # Push with callback when supported; otherwise, use on_screen_dismissed fallback
-        try:
-            self.app.push_screen(picker, _set_path)  # type: ignore[arg-type]
-        except TypeError:
-            self._opensearch_data_pick_callback = _set_path  # type: ignore[attr-defined]
             self.app.push_screen(picker)
 
     def action_pick_langflow_data_path(self) -> None:

--- a/src/tui/screens/monitor.py
+++ b/src/tui/screens/monitor.py
@@ -551,23 +551,6 @@ class MonitorScreen(Screen):
         env_manager = EnvManager()
         env_manager.load_existing_env()
 
-        # Clear opensearch-data using container
-        yield False, "Clearing OpenSearch data..."
-        opensearch_data_path = Path(env_manager.config.opensearch_data_path.replace("$HOME", str(Path.home()))).expanduser()
-        if opensearch_data_path.exists():
-            async for success, message in self.container_manager.clear_opensearch_data_volume():
-                yield success, message
-                if not success and "failed" in message.lower():
-                    return
-
-            # Recreate empty opensearch-data directory
-            try:
-                opensearch_data_path.mkdir(parents=True, exist_ok=True)
-                yield True, "OpenSearch data directory recreated"
-            except Exception as e:
-                yield False, f"Error recreating opensearch-data directory: {e}"
-                return
-
         # Delete langflow-data directory (mirrors Makefile factory-reset behaviour)
         yield False, "Clearing Langflow data..."
         from tui.main import _resolve_langflow_data_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,8 +47,6 @@ async def onboard_system():
     except Exception as e:
         print(f"[DEBUG] Could not wipe OpenSearch indices: {e}")
 
-    # Initialize clients again (just to be safe, though already done)
-    await clients.initialize()
 
     # Create app and perform onboarding via API
     from main import create_app, startup_tasks

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,24 +34,20 @@ async def onboard_system():
         yield
         return
 
-    from pathlib import Path
-    import shutil
-
     # Delete any existing config to ensure clean onboarding
     config_file = Path("config/config.yaml")
     if config_file.exists():
         config_file.unlink()
 
-    # Clean up OpenSearch data directory to ensure fresh state for tests
-    opensearch_data_path = Path(os.getenv("OPENSEARCH_DATA_PATH", "./opensearch-data"))
-    if opensearch_data_path.exists():
-        try:
-            shutil.rmtree(opensearch_data_path)
-            print(f"[DEBUG] Cleaned up OpenSearch data directory: {opensearch_data_path}")
-        except Exception as e:
-            print(f"[DEBUG] Could not clean OpenSearch data directory: {e}")
+    # Clean up OpenSearch indices to ensure fresh state for tests
+    try:
+        await clients.initialize()
+        await clients.opensearch.indices.delete(index="_all", ignore_unavailable=True)
+        print("[DEBUG] Wiped all OpenSearch indices via API")
+    except Exception as e:
+        print(f"[DEBUG] Could not wipe OpenSearch indices: {e}")
 
-    # Initialize clients
+    # Initialize clients again (just to be safe, though already done)
     await clients.initialize()
 
     # Create app and perform onboarding via API


### PR DESCRIPTION
This pull request removes all configuration, code, and documentation related to persisting OpenSearch data on the host filesystem via the `OPENSEARCH_DATA_PATH` environment variable. OpenSearch data is now managed solely via a Docker named volume, simplifying setup and maintenance. As a result, related migration logic, configuration fields, and UI elements have been removed or updated, and all data resets now operate on the Docker volume rather than a directory.

**OpenSearch Data Path Removal and Volume Management:**

* Removed the `OPENSEARCH_DATA_PATH` environment variable from `.env.example`, `frontend/.env.test.example`, and all related documentation and configuration code, including its use in the TUI config, migration, and environment manager. (`[[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL57-L60)`, `[[2]](diffhunk://#diff-8bf9c7d2ca83ba5411fc0260b75eb16b8c3594aba50c224b853cc3e972f197d9L9)`, `[[3]](diffhunk://#diff-72c3c3901a4d6baea27175427663092cc1878488406243cde36442d0d3265ed3L140)`, `[[4]](diffhunk://#diff-6e41c9c8008a4d431a159062b3a21caf92777fca9736a36db3e84f5bbe894f95L69-L74)`, `[[5]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL611)`, `[[6]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL691)`, `[[7]](diffhunk://#diff-5408077f55d63f67ee40e20ce9b6b1a19f84af6dfe1efaab8a8b4a731739bbc7L97)`, `[[8]](diffhunk://#diff-5408077f55d63f67ee40e20ce9b6b1a19f84af6dfe1efaab8a8b4a731739bbc7L215)`, `[[9]](diffhunk://#diff-5408077f55d63f67ee40e20ce9b6b1a19f84af6dfe1efaab8a8b4a731739bbc7L494-L496)`)
* Updated the OpenSearch data reset logic to clear the Docker named volume instead of a host directory, including changes to the `clear_opensearch_data.py` script and the `ContainerManager` class. (`[[1]](diffhunk://#diff-66b43037b92e4970806ee19b5321c13e55e0089a307a9c0cd8617c517e092fabL15-L37)`, `[[2]](diffhunk://#diff-26f4c29437cf0f797b720758fa7be3ce43e5018327378cf27893afd79f038c9eL1281-R1311)`, `[[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1017-R1012)`)
* Removed all migration logic and references related to moving or managing the `opensearch-data` directory in user home or project directories. (`[[1]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL565-R565)`, `[[2]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL587-R588)`, `[[3]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL758)`, `[[4]](diffhunk://#diff-55b27dbaf9d01c8ad5c293b8946007b112980c16553e6fb673068fd000ac7c6eL768)`)

**UI and TUI Configuration Cleanup:**

* Removed the OpenSearch data path field and its associated UI elements from the TUI configuration screen, including file pickers and special-case rendering logic. (`[[1]](diffhunk://#diff-42468bc83409b4be7c3754d4e742443aae1dead2bebd8f7c11ecda0dc41e17feL204)`, `[[2]](diffhunk://#diff-42468bc83409b4be7c3754d4e742443aae1dead2bebd8f7c11ecda0dc41e17feL292-L310)`, `[[3]](diffhunk://#diff-42468bc83409b4be7c3754d4e742443aae1dead2bebd8f7c11ecda0dc41e17feL478-L479)`, `[[4]](diffhunk://#diff-42468bc83409b4be7c3754d4e742443aae1dead2bebd8f7c11ecda0dc41e17feL625-L680)`)

**Makefile and Documentation Updates:**

* Updated the `Makefile` to remove references to deleting the `opensearch-data` directory and updated reset/clear commands and help text to reference the Docker volume instead. (`[[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L509)`, `[[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L527-L533)`, `[[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L1017-R1012)`)
* Updated documentation to remove mention of the `OPENSEARCH_DATA_PATH` variable and clarify that OpenSearch data is now managed via Docker volumes. (`[docs/docs/reference/configuration.mdxL140](diffhunk://#diff-72c3c3901a4d6baea27175427663092cc1878488406243cde36442d0d3265ed3L140)`)

These changes simplify OpenSearch management by using Docker volumes exclusively, reducing configuration complexity and potential user confusion.