### PR TITLE
chore: mcp allow pre release dependencies

### DIFF
--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag-mcp"
-version = "0.3.0rc2"
+version = "0.3.0rc3"
 description = "MCP server for OpenRAG"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,7 +22,6 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.0.0",
-    "httpx>=0.27.0",
     "openrag-sdk==0.3.0rc1",
 ]
 

--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag-mcp"
-version = "0.3.0rc1"
+version = "0.3.0rc2"
 description = "MCP server for OpenRAG"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -32,6 +32,9 @@ openrag-mcp = "openrag_mcp:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.envs.default]
+pip-args = ["--pre"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openrag_mcp"]

--- a/sdks/mcp/uv.lock
+++ b/sdks/mcp/uv.lock
@@ -332,17 +332,15 @@ wheels = [
 
 [[package]]
 name = "openrag-mcp"
-version = "0.3.0rc1"
+version = "0.3.0rc3"
 source = { editable = "." }
 dependencies = [
-    { name = "httpx" },
     { name = "mcp" },
     { name = "openrag-sdk" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "openrag-sdk", specifier = "==0.3.0rc1" },
 ]

--- a/sdks/mcp/uv.lock
+++ b/sdks/mcp/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "openrag-mcp"
-version = "0.3.0rc1"
+version = "0.3.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This pull request updates the MCP SDK's packaging configuration to improve versioning and dependency handling for pre-release installations.

Versioning:

* Bumped the project version from `0.3.0rc1` to `0.3.0rc2` in `pyproject.toml` to reflect the new release candidate.

Packaging and dependency management:

* Added a `[tool.hatch.envs.default]` section in `pyproject.toml` to specify `pip-args = ["--pre"]`, ensuring that pre-release dependencies are installed during development and testing.