### PR TITLE
fix: httpx resolution error in mcp 

### DIFF
--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag-mcp"
-version = "0.3.0rc3"
+version = "0.3.0rc4"
 description = "MCP server for OpenRAG"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,6 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.0.0",
+    "httpx>=0.28.0",  
     "openrag-sdk==0.3.0rc1",
 ]
 

--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag-mcp"
-version = "0.3.0rc2"
+version = "0.3.0rc3"
 description = "MCP server for OpenRAG"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -22,7 +22,6 @@ classifiers = [
 ]
 dependencies = [
     "mcp>=1.0.0",
-    "httpx>=0.27.0",
     "openrag-sdk==0.3.0rc1",
 ]
 

--- a/sdks/mcp/pyproject.toml
+++ b/sdks/mcp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openrag-mcp"
-version = "0.3.0rc1"
+version = "0.3.0rc2"
 description = "MCP server for OpenRAG"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -32,6 +32,9 @@ openrag-mcp = "openrag_mcp:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.envs.default]
+pip-args = ["--pre"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/openrag_mcp"]

--- a/sdks/mcp/uv.lock
+++ b/sdks/mcp/uv.lock
@@ -332,17 +332,15 @@ wheels = [
 
 [[package]]
 name = "openrag-mcp"
-version = "0.3.0rc1"
+version = "0.3.0rc3"
 source = { editable = "." }
 dependencies = [
-    { name = "httpx" },
     { name = "mcp" },
     { name = "openrag-sdk" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "openrag-sdk", specifier = "==0.3.0rc1" },
 ]

--- a/sdks/mcp/uv.lock
+++ b/sdks/mcp/uv.lock
@@ -332,15 +332,17 @@ wheels = [
 
 [[package]]
 name = "openrag-mcp"
-version = "0.3.0rc3"
+version = "0.3.0rc4"
 source = { editable = "." }
 dependencies = [
+    { name = "httpx" },
     { name = "mcp" },
     { name = "openrag-sdk" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.28.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "openrag-sdk", specifier = "==0.3.0rc1" },
 ]

--- a/sdks/mcp/uv.lock
+++ b/sdks/mcp/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "openrag-mcp"
-version = "0.3.0rc1"
+version = "0.3.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
This pull request updates the `pyproject.toml` configuration for the `openrag-mcp` Python SDK, focusing on dependency management and build configuration improvements.

Dependency updates:

* Bumped the `httpx` dependency version from `0.27.0` to `0.28.0` to ensure compatibility with newer features or bug fixes.
* Updated the package version from `0.3.0rc1` to `0.3.0rc4` to reflect the latest release candidate.

Build and environment configuration:

* Added a `[tool.hatch.envs.default]` section with `pip-args = ["--pre"]` to allow installation of pre-release dependencies during development.