### PR TITLE
chore: sdk release 0.3.0

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag-sdk"
-version = "0.3.0rc1"
+version = "0.3.1"
 description = "Official Python SDK for OpenRAG API"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "openrag-sdk"
-version = "0.3.0rc1"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrag-sdk",
-  "version": "0.3.0rc1",
+  "version": "0.3.1",
   "description": "Official TypeScript/JavaScript SDK for OpenRAG API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
This pull request updates the version number for both the Python and TypeScript SDKs for OpenRAG from `0.3.0rc1` to `0.3.1`. No other changes are included.

Version updates:

* Bumped the version in `sdks/python/pyproject.toml` to `0.3.1` for the Python SDK.
* Bumped the version in `sdks/typescript/package.json` to `0.3.1` for the TypeScript SDK.