### PR TITLE
feat: Add debug logging for config path helpers

### DIFF
--- a/src/config/paths.py
+++ b/src/config/paths.py
@@ -6,7 +6,8 @@ Variables are read directly via ``os.getenv`` here to avoid circular imports
 """
 
 import os
-
+from utils.logging_config import get_logger
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Documents directory
@@ -17,6 +18,7 @@ def get_documents_path() -> str:
     Environment variable: OPENRAG_DOCUMENTS_PATH
     Default: ``openrag-documents``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_DOCUMENTS_PATH: {os.getenv('OPENRAG_DOCUMENTS_PATH')}")
     return os.getenv("OPENRAG_DOCUMENTS_PATH") or "openrag-documents"
 
 
@@ -29,6 +31,7 @@ def get_keys_path() -> str:
     Environment variable: OPENRAG_KEYS_PATH
     Default: ``keys``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_KEYS_PATH: {os.getenv('OPENRAG_KEYS_PATH')}")
     return os.getenv("OPENRAG_KEYS_PATH") or "keys"
 
 
@@ -41,6 +44,7 @@ def get_flows_path() -> str:
     Environment variable: OPENRAG_FLOWS_PATH
     Default: ``flows``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_FLOWS_PATH: {os.getenv('OPENRAG_FLOWS_PATH')}")
     return os.getenv("OPENRAG_FLOWS_PATH") or "flows"
 
 
@@ -50,6 +54,7 @@ def get_flows_backup_path() -> str:
     Environment variable: OPENRAG_FLOWS_BACKUP_PATH
     Default: ``<flows_path>/backup``
     """
+    logger.debug(f"OPENRAG_FLOWS_BACKUP_PATH: {os.getenv('OPENRAG_FLOWS_BACKUP_PATH')}")
     return os.getenv("OPENRAG_FLOWS_BACKUP_PATH") or os.path.join(get_flows_path(), "backup")
 
 
@@ -62,11 +67,14 @@ def get_config_path() -> str:
     Environment variable: OPENRAG_CONFIG_PATH
     Default: ``config``  (relative to the working directory)
     """
+
+    logger.debug(f"OPENRAG_CONFIG_PATH: {os.getenv('OPENRAG_CONFIG_PATH')}")
     return os.getenv("OPENRAG_CONFIG_PATH") or "config"
 
 
 def get_config_file_path() -> str:
     """Return the full path to the config.yaml file."""
+    logger.debug(f"get_config_file_path: {os.path.join(get_config_path(), 'config.yaml')}")
     return os.path.join(get_config_path(), "config.yaml")
 
 
@@ -79,6 +87,7 @@ def get_data_path() -> str:
     Environment variable: OPENRAG_DATA_PATH
     Default: ``data``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_DATA_PATH: {os.getenv('OPENRAG_DATA_PATH')}")
     return os.getenv("OPENRAG_DATA_PATH") or "data"
 
 
@@ -90,4 +99,5 @@ def get_data_file(filename: str) -> str:
         get_data_file("conversations.json")
         # → "data/conversations.json"  (or $OPENRAG_DATA_PATH/conversations.json)
     """
+    logger.debug(f"get_data_file: {os.path.join(get_data_path(), filename)}")
     return os.path.join(get_data_path(), filename)


### PR DESCRIPTION
Import a module-level logger and add logger.debug calls to each path helper in src/config/paths.py. The change logs the relevant environment variables and computed file paths (including get_config_file_path and get_data_file) to improve visibility when diagnosing configuration issues. No functional behavior of the getters is changed.