### PR TITLE
feat: add OpenAI-compatible local LLM endpoint support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,10 @@ WEBHOOK_BASE_URL=
 
 # Model Provider API Keys
 OPENAI_API_KEY=
+# Optional: Custom endpoint for OpenAI-compatible APIs (e.g. local vLLM, LMStudio, LocalAI).
+# When set, all OpenAI LLM and embedding requests will be sent to this URL instead of api.openai.com.
+# Example: OPENAI_ENDPOINT=http://localhost:8000
+OPENAI_ENDPOINT=
 ANTHROPIC_API_KEY=
 OLLAMA_ENDPOINT=
 WATSONX_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ documents/ibm_anthropic.pdf
 documents/docling.pdf
 /opensearch-data-new-lf
 /opensearch-data2
+my_research

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+span
 
 <img src="./docs/static/img/openrag-logo-dog.svg" alt="" width="120"/>
 
@@ -30,7 +30,7 @@ Users can upload, process, and query documents through a chat interface backed b
 
 Check out the [documentation](https://docs.openr.ag/) or get started with the [quickstart](https://docs.openr.ag/quickstart).
 
-Built with [FastAPI](https://fastapi.tiangolo.com/) and [Next.js](https://github.com/vercel/next.js). 
+Built with [FastAPI](https://fastapi.tiangolo.com/) and [Next.js](https://github.com/vercel/next.js).
 Powered by [OpenSearch](https://github.com/opensearch-project/OpenSearch), [Langflow](https://github.com/langflow-ai/langflow), and [Docling](https://github.com/docling-project/docling).
 
 ---
@@ -91,11 +91,13 @@ To get started with OpenRAG, see the installation guides in the OpenRAG document
 Integrate OpenRAG into your applications with our official SDKs:
 
 ### Python SDK
+
 ```bash
 pip install openrag-sdk
 ```
 
 **Quick Example:**
+
 ```python
 import asyncio
 from openrag_sdk import OpenRAGClient
@@ -114,11 +116,13 @@ if __name__ == "__main__":
 📖 [Full Python SDK Documentation](https://pypi.org/project/openrag-sdk/)
 
 ### TypeScript/JavaScript SDK
+
 ```bash
 npm install openrag-sdk
 ```
 
 **Quick Example:**
+
 ```typescript
 import { OpenRAGClient } from "openrag-sdk";
 
@@ -138,6 +142,7 @@ pip install openrag-mcp
 ```
 
 **Quick Example (Cursor/Claude Desktop config):**
+
 ```json
 {
   "mcpServers": {

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -182,7 +182,7 @@ async def test_lightweight_health(
     """Test provider health with lightweight check (no credits consumed)."""
 
     if provider == "openai":
-        await _test_openai_lightweight_health(api_key)
+        await _test_openai_lightweight_health(api_key, endpoint)
     elif provider == "watsonx":
         await _test_watsonx_lightweight_health(api_key, endpoint, project_id)
     elif provider == "ollama":
@@ -203,7 +203,7 @@ async def test_completion_with_tools(
     """Test completion with tool calling for the provider."""
 
     if provider == "openai":
-        await _test_openai_completion_with_tools(api_key, llm_model)
+        await _test_openai_completion_with_tools(api_key, llm_model, endpoint)
     elif provider == "watsonx":
         await _test_watsonx_completion_with_tools(api_key, llm_model, endpoint, project_id)
     elif provider == "ollama":
@@ -224,7 +224,7 @@ async def test_embedding(
     """Test embedding generation for the provider."""
 
     if provider == "openai":
-        await _test_openai_embedding(api_key, embedding_model)
+        await _test_openai_embedding(api_key, embedding_model, endpoint)
     elif provider == "watsonx":
         await _test_watsonx_embedding(api_key, embedding_model, endpoint, project_id)
     elif provider == "ollama":
@@ -234,11 +234,15 @@ async def test_embedding(
 
 
 # OpenAI validation functions
-async def _test_openai_lightweight_health(api_key: str) -> None:
+async def _test_openai_lightweight_health(api_key: str, endpoint: str = None) -> None:
     """Test OpenAI API key validity with lightweight check.
     
     Only checks if the API key is valid without consuming credits.
     Uses the /v1/models endpoint which doesn't consume credits.
+    
+    Args:
+        api_key: OpenAI API key.
+        endpoint: Custom base URL for OpenAI-compatible APIs.
     """
     try:
         headers = {
@@ -246,10 +250,13 @@ async def _test_openai_lightweight_health(api_key: str) -> None:
             "Content-Type": "application/json",
         }
 
+        base_url = endpoint.rstrip("/") if endpoint else "https://api.openai.com"
+        models_url = f"{base_url}/v1/models"
+
         async with httpx.AsyncClient() as client:
             # Use /v1/models endpoint which validates the key without consuming credits
             response = await client.get(
-                "https://api.openai.com/v1/models",
+                models_url,
                 headers=headers,
                 timeout=10.0,  # Short timeout for lightweight check
             )
@@ -269,13 +276,22 @@ async def _test_openai_lightweight_health(api_key: str) -> None:
         raise
 
 
-async def _test_openai_completion_with_tools(api_key: str, llm_model: str) -> None:
-    """Test OpenAI completion with tool calling."""
+async def _test_openai_completion_with_tools(api_key: str, llm_model: str, endpoint: str = None) -> None:
+    """Test OpenAI completion with tool calling.
+    
+    Args:
+        api_key: OpenAI API key.
+        llm_model: Model name to test.
+        endpoint: Custom base URL for OpenAI-compatible APIs.
+    """
     try:
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
+
+        base_url = endpoint.rstrip("/") if endpoint else "https://api.openai.com"
+        completions_url = f"{base_url}/v1/chat/completions"
 
         # Simple tool calling test
         base_payload = {
@@ -308,7 +324,7 @@ async def _test_openai_completion_with_tools(api_key: str, llm_model: str) -> No
             # Try with max_tokens first
             payload = {**base_payload, "max_tokens": 50}
             response = await client.post(
-                "https://api.openai.com/v1/chat/completions",
+                completions_url,
                 headers=headers,
                 json=payload,
                 timeout=30.0,
@@ -319,7 +335,7 @@ async def _test_openai_completion_with_tools(api_key: str, llm_model: str) -> No
                 logger.info("max_tokens parameter failed, trying max_completion_tokens instead")
                 payload = {**base_payload, "max_completion_tokens": 50}
                 response = await client.post(
-                    "https://api.openai.com/v1/chat/completions",
+                    completions_url,
                     headers=headers,
                     json=payload,
                     timeout=30.0,
@@ -340,13 +356,22 @@ async def _test_openai_completion_with_tools(api_key: str, llm_model: str) -> No
         raise
 
 
-async def _test_openai_embedding(api_key: str, embedding_model: str) -> None:
-    """Test OpenAI embedding generation."""
+async def _test_openai_embedding(api_key: str, embedding_model: str, endpoint: str = None) -> None:
+    """Test OpenAI embedding generation.
+    
+    Args:
+        api_key: OpenAI API key.
+        embedding_model: Embedding model name to test.
+        endpoint: Custom base URL for OpenAI-compatible APIs.
+    """
     try:
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         }
+
+        base_url = endpoint.rstrip("/") if endpoint else "https://api.openai.com"
+        embeddings_url = f"{base_url}/v1/embeddings"
 
         payload = {
             "model": embedding_model,
@@ -355,7 +380,7 @@ async def _test_openai_embedding(api_key: str, embedding_model: str) -> None:
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                "https://api.openai.com/v1/embeddings",
+                embeddings_url,
                 headers=headers,
                 json=payload,
                 timeout=30.0,

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -54,6 +54,7 @@ class SettingsUpdateBody(BaseModel):
     embedding_provider: Optional[str] = Field(None, pattern="^(openai|watsonx|ollama)$")
     index_name: Optional[str] = Field(None, min_length=1)
     openai_api_key: Optional[str] = Field(None, min_length=1)
+    openai_endpoint: Optional[str] = Field(None, min_length=1)
     anthropic_api_key: Optional[str] = Field(None, min_length=1)
     watsonx_api_key: Optional[str] = Field(None, min_length=1)
     watsonx_endpoint: Optional[str] = Field(None, min_length=1)
@@ -71,6 +72,7 @@ class OnboardingBody(BaseModel):
     embedding_provider: Optional[str] = Field(None, pattern="^(openai|watsonx|ollama)$")
     embedding_model: Optional[str] = Field(None, min_length=1)
     openai_api_key: Optional[str] = Field(None, min_length=1)
+    openai_endpoint: Optional[str] = Field(None, min_length=1)
     anthropic_api_key: Optional[str] = Field(None, min_length=1)
     watsonx_api_key: Optional[str] = Field(None, min_length=1)
     watsonx_endpoint: Optional[str] = Field(None, min_length=1)
@@ -116,6 +118,7 @@ class OnboardingStateConfig(BaseModel):
 
 class OpenAIProviderConfig(BaseModel):
     has_api_key: bool
+    endpoint: Optional[str]
     configured: bool
 
 class AnthropicProviderConfig(BaseModel):
@@ -340,6 +343,7 @@ async def get_settings(
             providers=ProvidersConfig(
                 openai=OpenAIProviderConfig(
                     has_api_key=bool(openrag_config.providers.openai.api_key),
+                    endpoint=openrag_config.providers.openai.endpoint or None,
                     configured=openrag_config.providers.openai.configured,
                 ),
                 anthropic=AnthropicProviderConfig(
@@ -428,6 +432,7 @@ async def update_settings(
             "llm_model",
             "embedding_model",
             "openai_api_key",
+            "openai_endpoint",
             "anthropic_api_key",
             "watsonx_api_key",
             "watsonx_endpoint",
@@ -695,6 +700,12 @@ async def update_settings(
             config_updated = True
             provider_updated = True
 
+        if body.openai_endpoint is not None:
+            current_config.providers.openai.endpoint = body.openai_endpoint.strip()
+            current_config.providers.openai.configured = True
+            config_updated = True
+            provider_updated = True
+
         if body.anthropic_api_key is not None and body.anthropic_api_key.strip():
             current_config.providers.anthropic.api_key = body.anthropic_api_key
             current_config.providers.anthropic.configured = True
@@ -759,6 +770,7 @@ async def update_settings(
                     status_code=400,
                 )
             current_config.providers.openai.api_key = ""
+            current_config.providers.openai.endpoint = ""
             current_config.providers.openai.configured = False
             if current_config.agent.llm_provider == "openai":
                 fb = _first_configured_llm_provider(current_config, "openai")
@@ -965,6 +977,11 @@ async def onboarding(
         # Update provider-specific credentials
         if body.openai_api_key:
             current_config.providers.openai.api_key = body.openai_api_key.strip()
+            current_config.providers.openai.configured = True
+            config_updated = True
+
+        if body.openai_endpoint:
+            current_config.providers.openai.endpoint = body.openai_endpoint.strip()
             current_config.providers.openai.configured = True
             config_updated = True
 

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 class OpenAIConfig:
     """OpenAI provider configuration."""
     api_key: str = ""
+    endpoint: str = ""
     configured: bool = False
 
 
@@ -256,6 +257,8 @@ class ConfigManager:
         # OpenAI provider settings
         if os.getenv("OPENAI_API_KEY"):
             config_data["providers"]["openai"]["api_key"] = os.getenv("OPENAI_API_KEY")
+        if os.getenv("OPENAI_ENDPOINT"):
+            config_data["providers"]["openai"]["endpoint"] = os.getenv("OPENAI_ENDPOINT")
 
         # Anthropic provider settings
         if os.getenv("ANTHROPIC_API_KEY"):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -449,7 +449,11 @@ class AppClients:
                 if config.providers.openai.api_key:
                     os.environ["OPENAI_API_KEY"] = config.providers.openai.api_key
                     logger.debug("Loaded OpenAI API key from config")
-                elif not os.environ.get("OPENAI_API_KEY"):
+                openai_endpoint = config.providers.openai.endpoint or None
+                if openai_endpoint:
+                    os.environ["OPENAI_API_BASE"] = openai_endpoint  # LiteLLM expects this name
+                    logger.debug("Loaded OpenAI endpoint from config: %s", openai_endpoint)
+                if not os.environ.get("OPENAI_API_KEY"):
                     # Provide dummy key to satisfy AsyncOpenAI constructor; 
                     # LiteLLM/MCP will handle routing to other providers if needed.
                     os.environ["OPENAI_API_KEY"] = "no-key-required"
@@ -485,6 +489,7 @@ class AppClients:
                 # Provide fallbacks if config loading failed
                 model_name = OPENAI_DEFAULT_EMBEDDING_MODEL
                 provider = "openai"
+                openai_endpoint = None
                 # Ensure a dummy key is available to satisfy the AsyncOpenAI constructor
                 # and avoid AuthenticationError if config loading failed.
                 if not os.environ.get("OPENAI_API_KEY"):
@@ -492,8 +497,9 @@ class AppClients:
                     logger.debug("Using dummy OpenAI API key fallback (config load failed)")
 
 
-            # API key for AsyncOpenAI constructor
+            # API key and base_url for AsyncOpenAI constructor
             api_key = os.environ.get("OPENAI_API_KEY")
+            base_url = openai_endpoint if openai_endpoint else None
 
             async def probe_http2():
                 """Returns True if HTTP/2 works, False to fall back to HTTP/1.1.
@@ -504,7 +510,7 @@ class AppClients:
                 caller's event loop, avoiding cross-loop SSL transport errors.
                 """
                 # Use a standard OpenAI client for the probe (only runs for OpenAI provider)
-                client = AsyncOpenAI(api_key=api_key)
+                client = AsyncOpenAI(api_key=api_key, base_url=base_url) if base_url else AsyncOpenAI(api_key=api_key)
                 logger.info(f"Probing client with HTTP/2 using model {model_name}...")
                 try:
                     await asyncio.wait_for(
@@ -537,9 +543,9 @@ class AppClients:
                     loop.close()
 
             try:
-                # Run the probe only for OpenAI provider; local and other providers
-                # (Ollama, WatsonX) typically use HTTP/1.1 for reliability.
-                if provider.lower() == "openai":
+                # Run the probe only for OpenAI provider without custom endpoint;
+                # local and other providers (Ollama, WatsonX) typically use HTTP/1.1 for reliability.
+                if provider.lower() == "openai" and not openai_endpoint:
                     # Run the probe in a separate thread with its own event loop.
                     # Only the probe result (bool) crosses the thread boundary;
                     # the production client is created here so its connections are
@@ -552,17 +558,23 @@ class AppClients:
                     logger.debug(f"Skipping HTTP/2 probe for provider: {provider}")
 
                 if use_http2:
-                    self._patched_async_client = patch_openai_with_mcp(AsyncOpenAI(api_key=api_key))
-                    logger.info(f"OpenAI-compatible client initialized with HTTP/2 (model: {model_name})")
+                    client_kwargs = {"api_key": api_key}
+                    if base_url:
+                        client_kwargs["base_url"] = base_url
+                    self._patched_async_client = patch_openai_with_mcp(AsyncOpenAI(**client_kwargs))
+                    logger.info(f"OpenAI-compatible client initialized with HTTP/2 (model: {model_name}, base_url: {base_url or 'default'})")
                 else:
                     http_client = httpx.AsyncClient(
                         http2=False,
                         timeout=httpx.Timeout(60.0, connect=10.0)
                     )
+                    client_kwargs = {"api_key": api_key, "http_client": http_client}
+                    if base_url:
+                        client_kwargs["base_url"] = base_url
                     self._patched_async_client = patch_openai_with_mcp(
-                        AsyncOpenAI(api_key=api_key, http_client=http_client)
+                        AsyncOpenAI(**client_kwargs)
                     )
-                    logger.info(f"OpenAI-compatible client initialized with HTTP/1.1 fallback (model: {model_name})")
+                    logger.info(f"OpenAI-compatible client initialized with HTTP/1.1 fallback (model: {model_name}, base_url: {base_url or 'default'})")
                 logger.info("Successfully initialized OpenAI client")
             except Exception as e:
                 logger.error(f"Failed to initialize OpenAI client: {e.__class__.__name__}: {str(e)}")

--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -62,7 +62,11 @@ class ModelsService:
                 # OpenAI
                 if config.providers.openai.api_key:
                     try:
-                        res = await self.get_openai_models(config.providers.openai.api_key, update_index=False)
+                        res = await self.get_openai_models(
+                            config.providers.openai.api_key,
+                            endpoint=config.providers.openai.endpoint or None,
+                            update_index=False,
+                        )
                         self.add_models(res, "openai", new_registry)
                     except Exception as e:
                         logger.debug(f"Could not fetch OpenAI models for registry: {str(e)}")
@@ -135,19 +139,29 @@ class ModelsService:
             
         return f"{provider_lower}/{model_name}" if provider_lower != "openai" else model_name
 
-    async def get_openai_models(self, api_key: str, update_index: bool = True) -> Dict[str, List[Dict[str, str]]]:
-        """Fetch available models from OpenAI API with lightweight validation"""
+    async def get_openai_models(self, api_key: str, endpoint: str = None, update_index: bool = True) -> Dict[str, List[Dict[str, str]]]:
+        """Fetch available models from OpenAI API with lightweight validation.
+        
+        Args:
+            api_key: OpenAI API key.
+            endpoint: Custom base URL for OpenAI-compatible APIs (e.g. local vLLM, LMStudio).
+                      When None, uses the default OpenAI API.
+            update_index: Whether to update the model registry.
+        """
         try:
             headers = {
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             }
 
+            base_url = endpoint.rstrip("/") if endpoint else "https://api.openai.com"
+            models_url = f"{base_url}/v1/models"
+
             async with httpx.AsyncClient() as client:
                 # Lightweight validation: just check if API key is valid
                 # This doesn't consume credits, only validates the key
                 response = await client.get(
-                    "https://api.openai.com/v1/models", headers=headers, timeout=10.0
+                    models_url, headers=headers, timeout=10.0
                 )
 
             if response.status_code == 200:


### PR DESCRIPTION
In personal development, home use, and enterprise internal use scenarios, we may not be able to directly use OpenAI's API. This can be further divided into two scenarios: one is accessing OpenAI through an enterprise proxy, and the other is a locally deployed large OpenAI-compatible model. Both scenarios require support for configurable OpenAI endpoints.