### PR TITLE
fix: Update knowledge-dropdown with pptx and xlsx file type support

### DIFF
--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -66,6 +66,12 @@ export const SUPPORTED_FILE_TYPES = {
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
     ".docx",
   ],
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+    ".xlsx",
+  ],
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": [
+    ".pptx",
+  ],
   "text/csv": [".csv"],
 };
 


### PR DESCRIPTION
This pull request expands the supported file types in the `SUPPORTED_FILE_TYPES` object in `knowledge-dropdown.tsx` to include additional Microsoft Office formats.

New supported file types:

* Added support for `.xlsx` (Excel spreadsheets) with MIME type `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`.
* Added support for `.pptx` (PowerPoint presentations) with MIME type `application/vnd.openxmlformats-officedocument.presentationml.presentation`.