### PR TITLE
fix: update knowledge-dropdown with pptx and xlsx file type support

### DIFF
--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -66,6 +66,12 @@ export const SUPPORTED_FILE_TYPES = {
   "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [
     ".docx",
   ],
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [
+    ".xlsx",
+  ],
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": [
+    ".pptx",
+  ],
   "text/csv": [".csv"],
 };
 


### PR DESCRIPTION
This pull request updates the list of supported file types in the `knowledge-dropdown` component to include additional Microsoft Office formats.

Supported file types expanded:

* Added support for `.xlsx` (Excel spreadsheets) by including the MIME type `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` in `SUPPORTED_FILE_TYPES` in `knowledge-dropdown.tsx`.
* Added support for `.pptx` (PowerPoint presentations) by including the MIME type `application/vnd.openxmlformats-officedocument.presentationml.presentation` in `SUPPORTED_FILE_TYPES` in `knowledge-dropdown.tsx`.