### PR TITLE
fix: Add deleting state to ensure proper loading state

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -97,6 +97,7 @@ function SearchPage() {
   const { parsedFilterData, queryOverride } = useKnowledgeFilter();
   const [selectedRows, setSelectedRows] = useState<File[]>([]);
   const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState(false);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
   const lastErrorRef = useRef<string | null>(null);
   const hasInitializedFailedFilesRef = useRef(false);
   const seenFailedFileKeysRef = useRef<Set<string>>(new Set());
@@ -589,6 +590,7 @@ function SearchPage() {
   const handleBulkDelete = async () => {
     if (selectedRows.length === 0) return;
 
+    setIsBulkDeleting(true);
     try {
       // Delete each file individually since the API expects one filename at a time
       const deletePromises = selectedRows.map((row) =>
@@ -628,7 +630,6 @@ function SearchPage() {
         );
       }
       setSelectedRows([]);
-      setShowBulkDeleteDialog(false);
 
       // Clear selection in the grid
       if (gridRef.current) {
@@ -640,6 +641,8 @@ function SearchPage() {
           ? error.message
           : "Failed to delete some documents",
       );
+    } finally {
+      setIsBulkDeleting(false);
       setShowBulkDeleteDialog(false);
     }
   };
@@ -859,7 +862,7 @@ function SearchPage() {
         description={`Are you sure you want to delete ${selectedRows.length} document${selectedRows.length > 1 ? "s" : ""}?`}
         confirmText={selectedRows.length > 1 ? "Delete all" : "Delete"}
         onConfirm={handleBulkDelete}
-        isLoading={deleteDocumentMutation.isPending}
+        isLoading={isBulkDeleting}
       >
         <p className="my-2">
           This will remove all chunks and data associated with these documents.


### PR DESCRIPTION
**Issue**                                                                                                                                                                                                          
                                                                                                                                                                                                                 
  The delete dialog's loading spinner never showed because of two bugs:                                                                                                                                          
                                                                                                                                                                                                                 
  1. useMutation has a single state machine. Calling mutateAsync in parallel (one per file) caused the first completed request to flip isPending back to false, even with others still in-flight.                
  2. The dialog's handleConfirm read isLoading from a stale closure — captured before the button was clicked when it was still false — so the guard meant to keep the dialog open did nothing.    
  
  This resulted in QA being able to click it twice resulting in a "No document found" error message as shown [here](https://github.ibm.com/lakehouse/tracker/issues/70225)           
                                                                                                                                                                                                                 
  **Fix**                                                                                                                                                                                                            
                                                                                                                                                                                                                 
  Replaced deleteDocumentMutation.isPending with a local isBulkDeleting state. It's set to true before the parallel deletes fire and cleared in a finally block, giving the spinner a stable, accurate signal    
  regardless of how many mutations are running.    