### PR TITLE
fix: Update jwt handling for saas Fetch latest docs

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1962,7 +1962,12 @@ async def refresh_openrag_docs(
 ) -> RefreshOpenRAGDocsResponse:
     """Manually refresh OpenRAG docs ingestion on demand."""
     try:
+        from config.settings import IBM_AUTH_ENABLED
         from main import refresh_default_openrag_docs
+
+        ingestion_jwt = (
+            user.jwt_token if IBM_AUTH_ENABLED and user and user.jwt_token else None
+        )
 
         refreshed = await refresh_default_openrag_docs(
             document_service=document_service,
@@ -1972,6 +1977,7 @@ async def refresh_openrag_docs(
             session_manager=session_manager,
             force=True,
             reason="manual",
+            jwt_token=ingestion_jwt,
         )
         return RefreshOpenRAGDocsResponse(
             message=(

--- a/src/main.py
+++ b/src/main.py
@@ -919,6 +919,7 @@ async def refresh_default_openrag_docs(
     session_manager,
     force: bool = False,
     reason: str = "startup",
+    jwt_token=None,
 ):
     """Refresh OpenRAG docs if remote content changed or when forced."""
     await TelemetryClient.send_event(
@@ -1009,6 +1010,7 @@ async def refresh_default_openrag_docs(
             task_service,
             langflow_file_service,
             session_manager,
+            jwt_token=jwt_token,
         )
         config.onboarding.openrag_docs_ingested_version = OPENRAG_VERSION
         # Keep docs version/signature metadata consistent after a refresh.


### PR DESCRIPTION
**Issue** https://github.ibm.com/lakehouse/tracker/issues/69227                                                                                                                               
                                                                                                                                                                                                                 
  Both paths eventually call _ingest_default_documents_url_langflow, which uses the jwt_token it's given — falling back to the session_manager's anonymous JWT only when none is passed.                         
                                                                                                                                                                                                                 
  - Onboarding (api/settings.py:1166) computed ingestion_jwt = user.jwt_token if IBM_AUTH_ENABLED and user and user.jwt_token else None and threaded it through → under IBM auth, ingestion ran as the real user.
  - Fetch latest docs (api/settings.py:1967) never passed jwt_token at all → always fell back to the anonymous JWT, which isn't valid for IBM-auth-protected OpenSearch/Langflow calls.                        
                                                                                                                                                                                                                 
  The fix:                                                                                                                                                                                                     
                                                                                                                                                                                                                 
  1. src/main.py:912 — added jwt_token=None param to refresh_default_openrag_docs and forwarded it into ingest_openrag_docs_when_ready.                                                                          
  2. src/api/settings.py:1964 refresh_openrag_docs — computes the same ingestion_jwt = user.jwt_token if IBM_AUTH_ENABLED and user and user.jwt_token else None as onboarding and passes it through.
                                                                                                                                                                                                                 
  Now the manual refresh runs as the authenticated user under IBM auth, matching onboarding.