### PR TITLE
fix: fixes the jwt in delete existing default docs

### DIFF
--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1978,7 +1978,6 @@ async def refresh_openrag_docs(
             force=True,
             reason="manual",
             jwt_token=ingestion_jwt,
-            user_id=user.user_id if user else None,
         )
         return RefreshOpenRAGDocsResponse(
             message=(

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1978,6 +1978,7 @@ async def refresh_openrag_docs(
             force=True,
             reason="manual",
             jwt_token=ingestion_jwt,
+            user_id=user.user_id if user else None,
         )
         return RefreshOpenRAGDocsResponse(
             message=(

--- a/src/main.py
+++ b/src/main.py
@@ -760,7 +760,9 @@ async def _materialize_default_docs_url_as_text_file(
     return temp_file.name
 
 
-async def _delete_existing_default_docs(session_manager, connector_type: str):
+async def _delete_existing_default_docs(
+    session_manager, connector_type: str, jwt_token=None, user_id=None
+):
     """Delete previously ingested default OpenRAG docs before reingestion."""
     from session_manager import AnonymousUser
 
@@ -771,16 +773,18 @@ async def _delete_existing_default_docs(session_manager, connector_type: str):
         return
 
     anonymous_user = AnonymousUser()
-    effective_jwt = None
-    if session_manager:
+    effective_jwt = jwt_token
+    effective_user_id = user_id or anonymous_user.user_id
+
+    if not effective_jwt:
         session_manager.get_user_opensearch_client(
-            anonymous_user.user_id, effective_jwt
+            anonymous_user.user_id, None
         )
         if hasattr(session_manager, "_anonymous_jwt"):
             effective_jwt = session_manager._anonymous_jwt
 
     opensearch_client = session_manager.get_user_opensearch_client(
-        anonymous_user.user_id, effective_jwt
+        effective_user_id, effective_jwt
     )
     delete_query = {
         "query": {
@@ -920,6 +924,7 @@ async def refresh_default_openrag_docs(
     force: bool = False,
     reason: str = "startup",
     jwt_token=None,
+    user_id=None,
 ):
     """Refresh OpenRAG docs if remote content changed or when forced."""
     await TelemetryClient.send_event(
@@ -1002,7 +1007,10 @@ async def refresh_default_openrag_docs(
             new_signature=signature,
         )
         await _delete_existing_default_docs(
-            session_manager, connector_type="openrag_docs"
+            session_manager,
+            connector_type="openrag_docs",
+            jwt_token=jwt_token,
+            user_id=user_id,
         )
         await ingest_openrag_docs_when_ready(
             document_service,

--- a/src/main.py
+++ b/src/main.py
@@ -761,9 +761,16 @@ async def _materialize_default_docs_url_as_text_file(
 
 
 async def _delete_existing_default_docs(
-    session_manager, connector_type: str, jwt_token=None, user_id=None
+    session_manager, connector_type: str, jwt_token=None
 ):
-    """Delete previously ingested default OpenRAG docs before reingestion."""
+    """Delete previously ingested default OpenRAG docs before reingestion.
+
+    Default docs are always owned by the anonymous user — the delete query
+    filters on that owner regardless of who triggered the refresh. The
+    optional ``jwt_token`` is used only for the OpenSearch auth header
+    (e.g. the caller's IBM Lakehouse Basic credentials when the managed
+    cluster won't accept the anonymous Bearer JWT).
+    """
     from session_manager import AnonymousUser
 
     if session_manager is None:
@@ -774,7 +781,6 @@ async def _delete_existing_default_docs(
 
     anonymous_user = AnonymousUser()
     effective_jwt = jwt_token
-    effective_user_id = user_id or anonymous_user.user_id
 
     if not effective_jwt:
         session_manager.get_user_opensearch_client(
@@ -784,7 +790,7 @@ async def _delete_existing_default_docs(
             effective_jwt = session_manager._anonymous_jwt
 
     opensearch_client = session_manager.get_user_opensearch_client(
-        effective_user_id, effective_jwt
+        anonymous_user.user_id, effective_jwt
     )
     delete_query = {
         "query": {
@@ -924,7 +930,6 @@ async def refresh_default_openrag_docs(
     force: bool = False,
     reason: str = "startup",
     jwt_token=None,
-    user_id=None,
 ):
     """Refresh OpenRAG docs if remote content changed or when forced."""
     await TelemetryClient.send_event(
@@ -1010,7 +1015,6 @@ async def refresh_default_openrag_docs(
             session_manager,
             connector_type="openrag_docs",
             jwt_token=jwt_token,
-            user_id=user_id,
         )
         await ingest_openrag_docs_when_ready(
             document_service,


### PR DESCRIPTION
The issue

  - _delete_existing_default_docs forces AnonymousUser + session_manager._anonymous_jwt regardless of caller.                                                                                 
  - create_user_opensearch_client (config/settings.py:813-818) wraps any token lacking a Basic  / Bearer  prefix as Authorization: Bearer <token>.                                            
  - Under IBM auth, the real caller's User.jwt_token is actually "Basic {lh_credentials}" — what the Lakehouse gateway requires. The anonymous JWT is just a signed OpenRAG token, which the  
  gateway rejects with plain-text Bad Request\n.                                                                                                                                              
  - Timing and symptom shape match: single round-trip ~19ms between the "Refreshing default OpenRAG docs" log and the error; no JSON body; "Deleted existing default OpenRAG docs" success log
   never appears.   