### PR TITLE
fix: picture descriptions update set to false by default.

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -291,10 +291,14 @@ function KnowledgeSourcesPage() {
   }, [settings.knowledge?.ocr]);
 
   useEffect(() => {
+    if (isCloudBrand) {
+      setPictureDescriptions(false);
+      return;
+    }
     if (settings.knowledge?.picture_descriptions !== undefined) {
       setPictureDescriptions(settings.knowledge.picture_descriptions);
     }
-  }, [settings.knowledge?.picture_descriptions]);
+  }, [settings.knowledge?.picture_descriptions, isCloudBrand]);
 
   const k = settings.knowledge;
   const knowledgeIngestDirty =
@@ -302,7 +306,8 @@ function KnowledgeSourcesPage() {
     chunkOverlap !== (k?.chunk_overlap ?? chunkOverlap) ||
     tableStructure !== (k?.table_structure ?? tableStructure) ||
     ocr !== (k?.ocr ?? ocr) ||
-    pictureDescriptions !== (k?.picture_descriptions ?? pictureDescriptions);
+    (!isCloudBrand &&
+      pictureDescriptions !== (k?.picture_descriptions ?? pictureDescriptions));
 
   // Handle auto-focus on LLM model selector when coming from provider setup
   useEffect(() => {
@@ -387,7 +392,7 @@ function KnowledgeSourcesPage() {
         chunk_overlap: chunkOverlap,
         table_structure: tableStructure,
         ocr,
-        picture_descriptions: pictureDescriptions,
+        picture_descriptions: isCloudBrand ? false : pictureDescriptions,
       },
       {
         onSuccess: () => setChunkValidationError(null),
@@ -1100,24 +1105,26 @@ function KnowledgeSourcesPage() {
                   onCheckedChange={handleOcrChange}
                 />
               </div>
-              <div className="flex items-center justify-between py-3">
-                <div className="flex-1">
-                  <Label
-                    htmlFor="picture-descriptions"
-                    className="text-base font-medium cursor-pointer pb-3"
-                  >
-                    Picture Descriptions
-                  </Label>
-                  <div className="text-sm text-muted-foreground">
-                    Adds captions for images. Ingest is slower when enabled.
+              {!isCloudBrand && (
+                <div className="flex items-center justify-between py-3">
+                  <div className="flex-1">
+                    <Label
+                      htmlFor="picture-descriptions"
+                      className="text-base font-medium cursor-pointer pb-3"
+                    >
+                      Picture Descriptions
+                    </Label>
+                    <div className="text-sm text-muted-foreground">
+                      Adds captions for images. Ingest is slower when enabled.
+                    </div>
                   </div>
+                  <Switch
+                    id="picture-descriptions"
+                    checked={pictureDescriptions}
+                    onCheckedChange={handlePictureDescriptionsChange}
+                  />
                 </div>
-                <Switch
-                  id="picture-descriptions"
-                  checked={pictureDescriptions}
-                  onCheckedChange={handlePictureDescriptionsChange}
-                />
-              </div>
+              )}
             </div>
             <div className="flex justify-end pt-2">
               <Button

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -601,7 +601,9 @@ async def update_settings(
                 logger.error(f"Failed to update docling settings in flow: {str(e)}")
 
         if body.picture_descriptions is not None:
-            current_config.knowledge.picture_descriptions = body.picture_descriptions
+            from config.settings import IBM_AUTH_ENABLED
+            effective_picture_descriptions = False if IBM_AUTH_ENABLED else body.picture_descriptions
+            current_config.knowledge.picture_descriptions = effective_picture_descriptions
             config_updated = True
             await TelemetryClient.send_event(
                 Category.SETTINGS_OPERATIONS,


### PR DESCRIPTION
This pull request updates the `KnowledgeSourcesPage` component to improve how the "picture descriptions" feature is handled for cloud-branded deployments. The main changes ensure that the "picture descriptions" option is disabled and hidden when the app is running in a cloud-branded environment, preventing users from interacting with this setting.

Feature gating for cloud-branded environments:

* The "picture descriptions" toggle is now hidden from the UI when `isCloudBrand` is true, so users in cloud-branded deployments cannot see or modify this setting. [[1]](diffhunk://#diff-490eed05723647ee1286a4486c413d13a487aae5776bea789c214c59bc0935e1R1108) [[2]](diffhunk://#diff-490eed05723647ee1286a4486c413d13a487aae5776bea789c214c59bc0935e1R1127)
* When `isCloudBrand` is true, the internal state for "picture descriptions" is automatically set to `false` and not updated from settings.
* When saving settings, the "picture descriptions" value is forcibly set to `false` for cloud-branded environments, regardless of the UI or previous state.
* The "dirty" state tracking for knowledge ingestion settings now ignores "picture descriptions" when `isCloudBrand` is true, preventing unnecessary change detection.